### PR TITLE
Overhaul of the handling of grid specifications and variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 devel
 docs/build/
+.ipynb_checkpoints/

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -43,7 +43,7 @@ qwckplot(Rend)
 
 **MeshArrays.jl** composite types contain array collections where arrays are typically inter-connected at their edges. It provides `exchange functions` that transfer data between neighbor arrays so that the user can extend the domain of computation as needed e.g. for interpolation or to compute spatial derivatives.
 
-The composite types specify how each array collection forms a mesh and provide information to allow `exchange` to dispatch to the appropriate method. Various configurations that are commonly used in `Earth System Models` are implemented using the concrete type called `gcmfaces`. Embedded arrays, or meshes, each represent a subdomain within, e.g., an Earth System Model grid.
+The composite types specify how each array collection forms a mesh and provide information to allow `exchange` to dispatch to the appropriate method. Various configurations that are commonly used in `Earth System Models` are implemented using the concrete type called `gcmfaces`. This type contains a `gcmgrid` instance that provides grid specifications (incl. location on disk). Embedded arrays, or meshes, each represent a subdomain within, e.g., an Earth System Model grid.
 
 The `gcmfaces` name derives from a [previous Matlab / Octave package](https://gcmfaces.readthedocs.io/en/latest/) that was introduced in [Forget et al., 2015](http://www.geosci-model-dev.net/8/3071/2015/), `doi:10.5194/gmd-8-3071-2015`, and inspired this `Julia` package. Here, `GCM` is an acronym for General Circulation Model, or Global Climate Model as described in [this wikipedia entry](https://en.wikipedia.org/wiki/General_circulation_model), and `faces` is just another name for meshes, arrays, facets, or subdomains.
 

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -13,7 +13,7 @@ include("gcmfaces_IO.jl");
 include("gcmfaces_demo.jl");
 
 
-export AbstractGcmfaces, gcmfaces, gcmsubset, fsize, fijind
+export AbstractGcmfaces, gcmfaces, gcmsubset, gcmgrid, fsize, fijind
 export exchange, gradient, convergence, smooth, mask
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
 export findtiles

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -24,7 +24,7 @@ function read_bin(fil::String,kt,kk,prec::DataType)
   mygrid=gcmgrid(MeshArrays.grDir, MeshArrays.grTopo, MeshArrays.nFaces,
                  MeshArrays.facesSize, MeshArrays.ioSize, MeshArrays.ioPrec)
 
-  (n1,n2)=mygrid["ioSize"]
+  (n1,n2)=mygrid.ioSize
 
   if prec==Float64;
     reclen=8;

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -21,9 +21,9 @@ function read_bin(fil::String,kt,kk,prec::DataType)
     error("non-empty kk option not implemented yet");
   end;
 
-  mygrid=Dict("grDir" => MeshArrays.grDir, "nFaces" => MeshArrays.nFaces,
-      "grTopo" => MeshArrays.grTopo, "ioSize" => MeshArrays.ioSize,
-      "facesSize" => MeshArrays.facesSize, "ioPrec" => MeshArrays.ioPrec)
+  mygrid=Dict("path" => MeshArrays.grDir, "class" => MeshArrays.grTopo,
+      "nFaces" => MeshArrays.nFaces, "fSize" => MeshArrays.facesSize,
+      "ioSize" => MeshArrays.ioSize, "ioPrec" => MeshArrays.ioPrec)
 
   (n1,n2)=mygrid["ioSize"]
 

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -21,7 +21,11 @@ function read_bin(fil::String,kt,kk,prec::DataType)
     error("non-empty kk option not implemented yet");
   end;
 
-  (n1,n2)=MeshArrays.ioSize;
+  mygrid=Dict("grDir" => MeshArrays.grDir, "nFaces" => MeshArrays.nFaces,
+      "grTopo" => MeshArrays.grTopo, "ioSize" => MeshArrays.ioSize,
+      "facesSize" => MeshArrays.facesSize, "ioPrec" => MeshArrays.ioPrec)
+
+  (n1,n2)=mygrid["ioSize"]
 
   if prec==Float64;
     reclen=8;
@@ -38,7 +42,8 @@ function read_bin(fil::String,kt,kk,prec::DataType)
 
   n3>1 ? s=(n1,n2,n3) : s=(n1,n2)
   v0=reshape(fld,s);
-  convert2gcmfaces(v0);
+
+  convert2gcmfaces(v0,mygrid)
 
 end
 

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -22,7 +22,8 @@ function read_bin(fil::String,kt,kk,prec::DataType)
   end;
 
   mygrid=gcmgrid(MeshArrays.grDir, MeshArrays.grTopo, MeshArrays.nFaces,
-                 MeshArrays.facesSize, MeshArrays.ioSize, MeshArrays.ioPrec)
+                 MeshArrays.facesSize, MeshArrays.ioSize, MeshArrays.ioPrec,
+                 x -> missing)
 
   (n1,n2)=mygrid.ioSize
 

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -2,28 +2,24 @@
 ## read_bin function with full list of argument
 
 """
-    read_bin(fil::String,kt,kk,prec::DataType)
+    read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec::DataType,mygrid::gcmgrid)
 
 Read model output from binary file and convert to gcmfaces structure. Other methods:
 
 ```
-read_bin(fil::String,prec::DataType)
-read_bin(fil::String)
+read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
+read_bin(fil::String,mygrid::gcmgrid)
 ```
 """
-function read_bin(fil::String,kt,kk,prec::DataType)
+function read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec::DataType,mygrid::gcmgrid)
 
-  if ~isempty(kt);
+  if ~ismissing(kt);
     error("non-empty kt option not implemented yet");
   end;
 
-  if ~isempty(kk);
+  if ~ismissing(kk);
     error("non-empty kk option not implemented yet");
   end;
-
-  mygrid=gcmgrid(MeshArrays.grDir, MeshArrays.grTopo, MeshArrays.nFaces,
-                 MeshArrays.facesSize, MeshArrays.ioSize, MeshArrays.ioPrec,
-                 x -> missing)
 
   (n1,n2)=mygrid.ioSize
 
@@ -49,12 +45,12 @@ end
 
 ## read_bin function with reduced list of argument
 
-function read_bin(fil::String,prec::DataType)
-  read_bin(fil,[],[],prec)
+function read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
+  read_bin(fil,missing,missing,prec,mygrid::gcmgrid)
 end
 
 ## read_bin function with reduced list of argument
 
 function read_bin(fil::String)
-  read_bin(fil,[],[],Float32)
+  read_bin(fil,missing,missing,Float32,mygrid::gcmgrid)
 end

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -21,9 +21,8 @@ function read_bin(fil::String,kt,kk,prec::DataType)
     error("non-empty kk option not implemented yet");
   end;
 
-  mygrid=Dict("path" => MeshArrays.grDir, "class" => MeshArrays.grTopo,
-      "nFaces" => MeshArrays.nFaces, "fSize" => MeshArrays.facesSize,
-      "ioSize" => MeshArrays.ioSize, "ioPrec" => MeshArrays.ioPrec)
+  mygrid=gcmgrid(MeshArrays.grDir, MeshArrays.grTopo, MeshArrays.nFaces,
+                 MeshArrays.facesSize, MeshArrays.ioSize, MeshArrays.ioPrec)
 
   (n1,n2)=mygrid["ioSize"]
 

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -2,20 +2,20 @@
 ## gradient methods
 
 """
-    gradient(inFLD::gcmfaces)
+    gradient(inFLD::gcmfaces,mygrid::Dict)
 
 Compute spatial derivatives. Other methods:
 ```
-gradient(inFLD::gcmfaces,doDIV::Bool)
+gradient(inFLD::gcmfaces,mygrid::Dict,doDIV::Bool)
 gradient(inFLD::gcmfaces,iDXC::gcmfaces,iDYC::gcmfaces)
 ```
 """
-function gradient(inFLD::gcmfaces)
-(dFLDdx, dFLDdy)=gradient(inFLD,true)
+function gradient(inFLD::gcmfaces,mygrid::Dict)
+(dFLDdx, dFLDdy)=gradient(inFLD,mygrid,true)
 return dFLDdx, dFLDdy
 end
 
-function gradient(inFLD::gcmfaces,doDIV::Bool)
+function gradient(inFLD::gcmfaces,mygrid::Dict,doDIV::Bool)
 
 exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
@@ -27,8 +27,8 @@ for a=1:inFLD.nFaces;
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
   tmpC=tmpA-view(exFLD.f[a],2:s1-1,1:s2-2)
   if doDIV
-    dFLDdx.f[a]=tmpB./MeshArrays.DXC.f[a]
-    dFLDdy.f[a]=tmpC./MeshArrays.DYC.f[a]
+    dFLDdx.f[a]=tmpB./mygrid["DXC"].f[a]
+    dFLDdy.f[a]=tmpC./mygrid["DYC"].f[a]
   else
     dFLDdx.f[a]=tmpB
     dFLDdy.f[a]=tmpC
@@ -124,18 +124,18 @@ end
 ## smooth function
 
 """
-    smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces)
+    smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::Dict)
 
 Smooth out scales below DXCsm / DYCsm via diffusion
 """
-function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces)
+function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::Dict)
 
 #important note:
 #input FLD should be land masked (NaN/1) by caller if needed
 
 #get land masks (NaN/1):
 mskC=fill(1.0,FLD) + 0.0 * mask(FLD)
-(mskW,mskS)=gradient(FLD,false)
+(mskW,mskS)=gradient(FLD,mygrid,false)
 mskW=fill(1.0,FLD) + 0.0 * mask(mskW)
 mskS=fill(1.0,FLD) + 0.0 * mask(mskS)
 
@@ -149,8 +149,8 @@ mskS=mask(mskS,0.0)
 iDXC=similar(FLD)
 iDYC=similar(FLD)
 for a=1:FLD.nFaces;
-  iDXC.f[a]=1.0./MeshArrays.DXC.f[a]
-  iDYC.f[a]=1.0./MeshArrays.DYC.f[a]
+  iDXC.f[a]=1.0./mygrid["DXC"].f[a]
+  iDYC.f[a]=1.0./mygrid["DYC"].f[a]
 end
 
 #Before scaling the diffusive operator ...
@@ -166,11 +166,11 @@ T=nbt*dt;
 #println("nbt="*"$nbt")
 
 #diffusion operator times DYG / DXG:
-KuxFac=mskW*DXCsm*DXCsm/T/2.0*MeshArrays.DYG;
-KvyFac=mskS*DYCsm*DYCsm/T/2.0*MeshArrays.DXG;
+KuxFac=mskW*DXCsm*DXCsm/T/2.0*mygrid["DYG"];
+KvyFac=mskS*DYCsm*DYCsm/T/2.0*mygrid["DXG"];
 
 #time steping factor:
-dtFac=dt*mskC/MeshArrays.RAC;
+dtFac=dt*mskC/mygrid["RAC"];
 
 #loop:
 for it=1:nbt
@@ -198,11 +198,11 @@ end
 ## TransportThrough function
 
 """
-    TransportThrough(VectorField,IntegralPath)
+    TransportThrough(VectorField,IntegralPath,mygrid::Dict)
 
 Compute transport through an integration path
 """
-function TransportThrough(VectorField,IntegralPath)
+function TransportThrough(VectorField,IntegralPath,mygrid::Dict)
 
     #Note: vertical intergration is not always wanted; left for user to do outside
 
@@ -228,11 +228,11 @@ function TransportThrough(VectorField,IntegralPath)
     for i3=1:n[3]
         #method 1: quite slow
         #mskW=IntegralPath["mskW"]
-        #do_dxory==1 ? mskW=mskW*MeshArrays.DYG : nothing
-        #do_dz==1 ? mskW=MeshArrays.DRF[i3]*mskW : nothing
+        #do_dxory==1 ? mskW=mskW*mygrid["DYG"] : nothing
+        #do_dz==1 ? mskW=mygrid["DRF"][i3]*mskW : nothing
         #mskS=IntegralPath["mskS"]
-        #do_dxory==1 ? mskS=mskS*MeshArrays.DXG : nothing
-        #do_dz==1 ? mskS=MeshArrays.DRF[i3]*mskS : nothing
+        #do_dxory==1 ? mskS=mskS*mygrid["DXG"] : nothing
+        #do_dz==1 ? mskS=mygrid["DRF"][i3]*mskS : nothing
         #
         #method 2: less slow
         tabW=IntegralPath["tabW"]
@@ -245,14 +245,14 @@ function TransportThrough(VectorField,IntegralPath)
             trsp[1,i3,i4]=0.0
             for k=1:size(tabW,1)
                 (a,i1,i2,w)=tabW[k,:]
-                do_dxory==1 ? w=w*MeshArrays.DYG.f[a][i1,i2] : nothing
-                do_dz==1 ? w=w*MeshArrays.DRF[i3] : nothing
+                do_dxory==1 ? w=w*mygrid["DYG"].f[a][i1,i2] : nothing
+                do_dz==1 ? w=w*mygrid["DRF"][i3] : nothing
                 trsp[1,i3,i4]=trsp[1,i3,i4]+w*U.f[a][i1,i2,i3,i4]
             end
             for k=1:size(tabS,1)
                 (a,i1,i2,w)=tabS[k,:]
-                do_dxory==1 ? w=w*MeshArrays.DXG.f[a][i1,i2] : nothing
-                do_dz==1 ? w=w*MeshArrays.DRF[i3] : nothing
+                do_dxory==1 ? w=w*mygrid["DXG"].f[a][i1,i2] : nothing
+                do_dz==1 ? w=w*mygrid["DRF"][i3] : nothing
                 trsp[1,i3,i4]=trsp[1,i3,i4]+w*V.f[a][i1,i2,i3,i4]
             end
         end
@@ -264,16 +264,16 @@ end
 ## LatCircles function
 
 """
-    LatCircles(LatValues)
+    LatCircles(LatValues,mygrid::Dict)
 
 Compute integration paths that follow latitude circles
 """
-function LatCircles(LatValues)
+function LatCircles(LatValues,mygrid::Dict)
 
     LatCircles=Array{Dict}(undef,length(LatValues))
 
     for j=1:length(LatValues)
-        mskCint=1*(MeshArrays.YC .>= LatValues[j])
+        mskCint=1*(mygrid["YC"] .>= LatValues[j])
         mskC=similar(mskCint)
         mskW=similar(mskCint)
         mskS=similar(mskCint)

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -21,7 +21,7 @@ exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
-for a=1:inFLD.grid["nFaces"];
+for a=1:inFLD.grid.nFaces
   (s1,s2)=fsize(exFLD,a)
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -44,7 +44,7 @@ exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
-for a=1:inFLD.grid["nFaces"];
+for a=1:inFLD.grid.nFaces
   (s1,s2)=fsize(exFLD,a)
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -74,7 +74,7 @@ mask(fld::gcmfaces, val::Number, noval::Number)
 """
 function mask(fld::gcmfaces, val::Number)
   fldmsk=similar(fld)
-  for a=1:fld.grid["nFaces"]
+  for a=1:fld.grid.nFaces
     tmp1=copy(fld.f[a])
     replace!(x -> !isfinite(x) ? val : x, tmp1 )
     fldmsk.f[a]=tmp1
@@ -84,7 +84,7 @@ end
 
 function mask(fld::gcmfaces, val::Number, noval::Number)
   fldmsk=similar(fld)
-  for a=1:fld.grid["nFaces"]
+  for a=1:fld.grid.nFaces
     tmp1=copy(fld.f[a])
     replace!(x -> x==noval ? val : x, tmp1  )
     fldmsk.f[a]=tmp1
@@ -109,7 +109,7 @@ function convergence(uFLD::gcmfaces,vFLD::gcmfaces)
 CONV=similar(uFLD)
 
 (tmpU,tmpV)=exch_UV(uFLD,vFLD)
-for a=1:tmpU.grid["nFaces"]
+for a=1:tmpU.grid.nFaces
   (s1,s2)=fsize(uFLD,a)
   tmpU1=view(tmpU.f[a],1:s1,1:s2)
   tmpU2=view(tmpU.f[a],2:s1+1,1:s2)
@@ -148,7 +148,7 @@ mskS=mask(mskS,0.0)
 #get inverse grid spacing:
 iDXC=similar(FLD)
 iDYC=similar(FLD)
-for a=1:FLD.grid["nFaces"];
+for a=1:FLD.grid.nFaces
   iDXC.f[a]=1.0./mygrid["DXC"].f[a]
   iDYC.f[a]=1.0./mygrid["DYC"].f[a]
 end
@@ -177,12 +177,12 @@ for it=1:nbt
   (dTdxAtU,dTdyAtV)=gradient(FLD,iDXC,iDYC);
   tmpU=similar(FLD)
   tmpV=similar(FLD)
-  for a=1:FLD.grid["nFaces"]
+  for a=1:FLD.grid.nFaces
       tmpU.f[a]=dTdxAtU.f[a].*KuxFac.f[a];
       tmpV.f[a]=dTdyAtV.f[a].*KvyFac.f[a];
   end
   tmpC=convergence(tmpU,tmpV);
-  for a=1:FLD.grid["nFaces"]
+  for a=1:FLD.grid.nFaces
       FLD.f[a]=FLD.f[a]-dtFac.f[a].*tmpC.f[a];
   end
 end
@@ -280,7 +280,7 @@ function LatCircles(LatValues,mygrid::gcmgrid)
 
         mskCint=exchange(mskCint,1)
 
-        for i=1:mskCint.grid["nFaces"]
+        for i=1:mskCint.grid.nFaces
             tmp1=mskCint.f[i]
             # tracer mask:
             tmp2=tmp1[2:end-1,1:end-2]+tmp1[2:end-1,3:end]+

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -2,20 +2,20 @@
 ## gradient methods
 
 """
-    gradient(inFLD::gcmfaces,mygrid::Dict)
+    gradient(inFLD::gcmfaces,mygrid::gcmgrid)
 
 Compute spatial derivatives. Other methods:
 ```
-gradient(inFLD::gcmfaces,mygrid::Dict,doDIV::Bool)
+gradient(inFLD::gcmfaces,mygrid::gcmgrid,doDIV::Bool)
 gradient(inFLD::gcmfaces,iDXC::gcmfaces,iDYC::gcmfaces)
 ```
 """
-function gradient(inFLD::gcmfaces,mygrid::Dict)
+function gradient(inFLD::gcmfaces,mygrid::gcmgrid)
 (dFLDdx, dFLDdy)=gradient(inFLD,mygrid,true)
 return dFLDdx, dFLDdy
 end
 
-function gradient(inFLD::gcmfaces,mygrid::Dict,doDIV::Bool)
+function gradient(inFLD::gcmfaces,mygrid::gcmgrid,doDIV::Bool)
 
 exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
@@ -124,11 +124,11 @@ end
 ## smooth function
 
 """
-    smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::Dict)
+    smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::gcmgrid)
 
 Smooth out scales below DXCsm / DYCsm via diffusion
 """
-function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::Dict)
+function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,mygrid::gcmgrid)
 
 #important note:
 #input FLD should be land masked (NaN/1) by caller if needed
@@ -198,11 +198,11 @@ end
 ## TransportThrough function
 
 """
-    TransportThrough(VectorField,IntegralPath,mygrid::Dict)
+    TransportThrough(VectorField,IntegralPath,mygrid::gcmgrid)
 
 Compute transport through an integration path
 """
-function TransportThrough(VectorField,IntegralPath,mygrid::Dict)
+function TransportThrough(VectorField,IntegralPath,mygrid::gcmgrid)
 
     #Note: vertical intergration is not always wanted; left for user to do outside
 
@@ -264,11 +264,11 @@ end
 ## LatCircles function
 
 """
-    LatCircles(LatValues,mygrid::Dict)
+    LatCircles(LatValues,mygrid::gcmgrid)
 
 Compute integration paths that follow latitude circles
 """
-function LatCircles(LatValues,mygrid::Dict)
+function LatCircles(LatValues,mygrid::gcmgrid)
 
     LatCircles=Array{Dict}(undef,length(LatValues))
 

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -21,7 +21,7 @@ exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
-for a=1:inFLD.nFaces;
+for a=1:inFLD.grid["nFaces"];
   (s1,s2)=fsize(exFLD,a)
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -44,7 +44,7 @@ exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
-for a=1:inFLD.nFaces;
+for a=1:inFLD.grid["nFaces"];
   (s1,s2)=fsize(exFLD,a)
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -74,7 +74,7 @@ mask(fld::gcmfaces, val::Number, noval::Number)
 """
 function mask(fld::gcmfaces, val::Number)
   fldmsk=similar(fld)
-  for a=1:fld.nFaces
+  for a=1:fld.grid["nFaces"]
     tmp1=copy(fld.f[a])
     replace!(x -> !isfinite(x) ? val : x, tmp1 )
     fldmsk.f[a]=tmp1
@@ -84,7 +84,7 @@ end
 
 function mask(fld::gcmfaces, val::Number, noval::Number)
   fldmsk=similar(fld)
-  for a=1:fld.nFaces
+  for a=1:fld.grid["nFaces"]
     tmp1=copy(fld.f[a])
     replace!(x -> x==noval ? val : x, tmp1  )
     fldmsk.f[a]=tmp1
@@ -109,7 +109,7 @@ function convergence(uFLD::gcmfaces,vFLD::gcmfaces)
 CONV=similar(uFLD)
 
 (tmpU,tmpV)=exch_UV(uFLD,vFLD)
-for a=1:tmpU.nFaces
+for a=1:tmpU.grid["nFaces"]
   (s1,s2)=fsize(uFLD,a)
   tmpU1=view(tmpU.f[a],1:s1,1:s2)
   tmpU2=view(tmpU.f[a],2:s1+1,1:s2)
@@ -148,7 +148,7 @@ mskS=mask(mskS,0.0)
 #get inverse grid spacing:
 iDXC=similar(FLD)
 iDYC=similar(FLD)
-for a=1:FLD.nFaces;
+for a=1:FLD.grid["nFaces"];
   iDXC.f[a]=1.0./mygrid["DXC"].f[a]
   iDYC.f[a]=1.0./mygrid["DYC"].f[a]
 end
@@ -177,12 +177,12 @@ for it=1:nbt
   (dTdxAtU,dTdyAtV)=gradient(FLD,iDXC,iDYC);
   tmpU=similar(FLD)
   tmpV=similar(FLD)
-  for a=1:FLD.nFaces
+  for a=1:FLD.grid["nFaces"]
       tmpU.f[a]=dTdxAtU.f[a].*KuxFac.f[a];
       tmpV.f[a]=dTdyAtV.f[a].*KvyFac.f[a];
   end
   tmpC=convergence(tmpU,tmpV);
-  for a=1:FLD.nFaces
+  for a=1:FLD.grid["nFaces"]
       FLD.f[a]=FLD.f[a]-dtFac.f[a].*tmpC.f[a];
   end
 end
@@ -280,7 +280,7 @@ function LatCircles(LatValues,mygrid::Dict)
 
         mskCint=exchange(mskCint,1)
 
-        for i=1:mskCint.nFaces
+        for i=1:mskCint.grid["nFaces"]
             tmp1=mskCint.f[i]
             # tracer mask:
             tmp2=tmp1[2:end-1,1:end-2]+tmp1[2:end-1,3:end]+

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -8,16 +8,16 @@ Convert gcmfaces to array or vice versa
 """
 function convert2array(fld::gcmfaces)
 
-if fld.grid["class"]=="llc";
+if fld.grid.class=="llc";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     arr=cat(tmp1,tmp2;dims=2);
-elseif fld.grid["class"]=="cs";
+elseif fld.grid.class=="cs";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     tmp0=cat(NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3],rotr90(fld.f[6]);dims=1);
     arr=cat(tmp0,tmp1,tmp2;dims=2);
-elseif fld.grid["class"]=="ll";
+elseif fld.grid.class=="ll";
   arr=fld.f[1];
 else;
   error("unknown grTopo case");
@@ -31,9 +31,9 @@ end
 
 function convert2array(fld::Array{T,N},grid::gcmgrid) where {T,N}
 
-grTopo=grid["class"]
-nFaces=grid["nFaces"]
-facesSize=grid["fSize"]
+grTopo=grid.class
+nFaces=grid.nFaces
+facesSize=grid.fSize
 
 v1=Array{Array{T,N},1}(undef,nFaces);
 N>2 ? error("N>2 case not implemented yet") : nothing
@@ -72,10 +72,10 @@ Convert mitgcm output to gcmfaces or vice versa
 """
 function convert2gcmfaces(fld::gcmfaces)
 
-    grTopo=fld.grid["class"]
-    nFaces=fld.grid["nFaces"]
-    (n1,n2)=fld.grid["ioSize"]
-    facesSize=fld.grid["fSize"]
+    grTopo=fld.grid.class
+    nFaces=fld.grid.nFaces
+    (n1,n2)=fld.grid.ioSize
+    facesSize=fld.grid.fSize
 
     aa=0;bb=0;
     for iFace=1:nFaces;
@@ -104,10 +104,10 @@ end
 
 function convert2gcmfaces(fld::Array,grid::gcmgrid)
 
-grTopo=grid["class"]
-nFaces=grid["nFaces"]
-(n1,n2)=grid["ioSize"]
-facesSize=grid["fSize"]
+grTopo=grid.class
+nFaces=grid.nFaces
+(n1,n2)=grid.ioSize
+facesSize=grid.fSize
 
 n3=Int64(prod(size(fld))/n1/n2);
 

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -29,36 +29,37 @@ end
 
 ## convert2array ##
 
-function convert2array(fld::Array{T,N}) where {T,N}
+function convert2array(fld::Array{T,N},grid::Dict) where {T,N}
 
-grTopo=MeshArrays.grTopo;
-nFaces=MeshArrays.nFaces;
+grTopo=grid["grTopo"]
+nFaces=grid["nFaces"]
+facesSize=grid["facesSize"]
 
 v1=Array{Array{T,N},1}(undef,nFaces);
 N>2 ? error("N>2 case not implemented yet") : nothing
 
-if MeshArrays.grTopo=="llc";
-    (n1,n2)=MeshArrays.facesSize[1];
+if grTopo=="llc";
+    (n1,n2)=facesSize[1];
     v1[1]=fld[1:n1,1:n2];
     v1[2]=fld[n1+1:n1*2,1:n2];
     v1[3]=rotr90(fld[1:n1,n2+1:n2+n1]);
     v1[4]=rotl90(fld[n1*2+1:n1*3,1:n2]);
     v1[5]=rotl90(fld[n1*3+1:n1*4,1:n2]);
-elseif MeshArrays.grTopo=="cs";
-    (n1,n2)=MeshArrays.facesSize[1];
+elseif grTopo=="cs";
+    (n1,n2)=facesSize[1];
     v1[1]=fld[1:n1,n1+1:n1+n2];
     v1[2]=fld[n1+1:2*n1,n1+1:n1+n2];
     v1[3]=rotr90(fld[1:n1,n1+n2+1:n2+n1*2]);
     v1[4]=rotl90(fld[n1*2+1:n1*3,n1+1:n1+n2]);
     v1[5]=rotl90(fld[n1*3+1:n1*4,n1+1:n1+n2]);
     v1[6]=rotl90(fld[n1*3+1:n1*4,1:n1]);
-elseif MeshArrays.grTopo=="ll";
+elseif grTopo=="ll";
     v1[1]=fld;
 else;
   error("unknown grTopo case");
 end;
 
-gcmfaces(nFaces,grTopo,v1);
+gcmfaces(grid,v1);
 
 end
 
@@ -71,10 +72,10 @@ Convert mitgcm output to gcmfaces or vice versa
 """
 function convert2gcmfaces(fld::gcmfaces)
 
-    grTopo=MeshArrays.grTopo;
-    nFaces=MeshArrays.nFaces;
-    (n1,n2)=MeshArrays.ioSize;
-    facesSize=MeshArrays.facesSize;
+    grTopo=fld.grid["grTopo"]
+    nFaces=fld.grid["nFaces"]
+    (n1,n2)=fld.grid["ioSize"]
+    facesSize=fld.grid["facesSize"]
 
     aa=0;bb=0;
     for iFace=1:nFaces;
@@ -101,12 +102,12 @@ end
 
 ## convert2gcmfaces ##
 
-function convert2gcmfaces(fld::Array)
+function convert2gcmfaces(fld::Array,grid::Dict)
 
-grTopo=MeshArrays.grTopo;
-nFaces=MeshArrays.nFaces;
-(n1,n2)=MeshArrays.ioSize;
-facesSize=MeshArrays.facesSize;
+grTopo=grid["grTopo"]
+nFaces=grid["nFaces"]
+(n1,n2)=grid["ioSize"]
+facesSize=grid["facesSize"]
 
 n3=Int64(prod(size(fld))/n1/n2);
 
@@ -124,6 +125,6 @@ for iFace=1:nFaces
   end;
 end
 
-gcmfaces(nFaces,grTopo,v1);
+gcmfaces(grid,v1);
 
 end

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -29,7 +29,7 @@ end
 
 ## convert2array ##
 
-function convert2array(fld::Array{T,N},grid::Dict) where {T,N}
+function convert2array(fld::Array{T,N},grid::gcmgrid) where {T,N}
 
 grTopo=grid["class"]
 nFaces=grid["nFaces"]
@@ -102,7 +102,7 @@ end
 
 ## convert2gcmfaces ##
 
-function convert2gcmfaces(fld::Array,grid::Dict)
+function convert2gcmfaces(fld::Array,grid::gcmgrid)
 
 grTopo=grid["class"]
 nFaces=grid["nFaces"]

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -8,16 +8,16 @@ Convert gcmfaces to array or vice versa
 """
 function convert2array(fld::gcmfaces)
 
-if fld.grTopo=="llc";
+if fld.grid["grTopo"]=="llc";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     arr=cat(tmp1,tmp2;dims=2);
-elseif fld.grTopo=="cs";
+elseif fld.grid["grTopo"]=="cs";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     tmp0=cat(NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3],rotr90(fld.f[6]);dims=1);
     arr=cat(tmp0,tmp1,tmp2;dims=2);
-elseif fld.grTopo=="ll";
+elseif fld.grid["grTopo"]=="ll";
   arr=fld.f[1];
 else;
   error("unknown grTopo case");

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -8,16 +8,16 @@ Convert gcmfaces to array or vice versa
 """
 function convert2array(fld::gcmfaces)
 
-if fld.grid["grTopo"]=="llc";
+if fld.grid["class"]=="llc";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     arr=cat(tmp1,tmp2;dims=2);
-elseif fld.grid["grTopo"]=="cs";
+elseif fld.grid["class"]=="cs";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
     tmp2=cat(rotl90(fld.f[3]),NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3];dims=1);
     tmp0=cat(NaN*fld.f[3],NaN*fld.f[3],NaN*fld.f[3],rotr90(fld.f[6]);dims=1);
     arr=cat(tmp0,tmp1,tmp2;dims=2);
-elseif fld.grid["grTopo"]=="ll";
+elseif fld.grid["class"]=="ll";
   arr=fld.f[1];
 else;
   error("unknown grTopo case");
@@ -31,9 +31,9 @@ end
 
 function convert2array(fld::Array{T,N},grid::Dict) where {T,N}
 
-grTopo=grid["grTopo"]
+grTopo=grid["class"]
 nFaces=grid["nFaces"]
-facesSize=grid["facesSize"]
+facesSize=grid["fSize"]
 
 v1=Array{Array{T,N},1}(undef,nFaces);
 N>2 ? error("N>2 case not implemented yet") : nothing
@@ -72,10 +72,10 @@ Convert mitgcm output to gcmfaces or vice versa
 """
 function convert2gcmfaces(fld::gcmfaces)
 
-    grTopo=fld.grid["grTopo"]
+    grTopo=fld.grid["class"]
     nFaces=fld.grid["nFaces"]
     (n1,n2)=fld.grid["ioSize"]
-    facesSize=fld.grid["facesSize"]
+    facesSize=fld.grid["fSize"]
 
     aa=0;bb=0;
     for iFace=1:nFaces;
@@ -104,10 +104,10 @@ end
 
 function convert2gcmfaces(fld::Array,grid::Dict)
 
-grTopo=grid["grTopo"]
+grTopo=grid["class"]
 nFaces=grid["nFaces"]
 (n1,n2)=grid["ioSize"]
-facesSize=grid["facesSize"]
+facesSize=grid["fSize"]
 
 n3=Int64(prod(size(fld))/n1/n2);
 

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -2,9 +2,9 @@
 ## convert2array method:
 
 """
-    convert2array(fld)
+    convert2array(fld::gcmfaces)
 
-Convert gcmfaces to array or vice versa
+Convert gcmfaces to array (or vice versa)
 """
 function convert2array(fld::gcmfaces)
 
@@ -68,7 +68,7 @@ end
 """
     convert2gcmfaces(fld::gcmfaces)
 
-Convert mitgcm output to gcmfaces or vice versa
+Convert mitgcm output to gcmfaces (or vice versa)
 """
 function convert2gcmfaces(fld::gcmfaces)
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -7,14 +7,16 @@ demo1(gridChoice)
 Demonstrate basic fucntions (arithmetic, exchange, GCMGridLoad, gradient, etc.). Example call:
 
 ```
-isdir("GRID_LLC90") ? (D,Dexch,Darr,DD)=demo1("LLC90") : nothing
+!isdir("GRID_LLC90") ? error("missing files") : nothing
+
+(D,Dexch,Darr,DD)=demo1("LLC90");
 ```
 """
 function demo1(gridChoice)
 
-    GCMGridSpec(gridChoice)
+    mygrid=GCMGridSpec(gridChoice)
 
-    D=read_bin(MeshArrays.grDir*"Depth.data",MeshArrays.ioPrec)
+    D=read_bin(mygrid["grDir"]*"Depth.data",mygrid["ioPrec"])
 
     1000+D
     D+1000
@@ -33,14 +35,14 @@ function demo1(gridChoice)
     Darr=convert2array(D)
     DD=convert2array(Darr)
 
-    GCMGridLoad()
+    mygrid=GCMGridLoad(mygrid)
 
-    (dFLDdx, dFLDdy)=gradient(MeshArrays.YC)
+    (dFLDdx, dFLDdy)=gradient(mygrid["YC"])
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
-    view(MeshArrays.hFacC,:,:,40)
-    #show(fsize(MeshArrays.hFacC,1))
-    #show(fsize(view(MeshArrays.hFacC,:,:,40),1))
+    view(mygrid["hFacC"],:,:,40)
+    #show(fsize(mygrid["hFacC"],1))
+    #show(fsize(view(mygrid["hFacC"],:,:,40),1))
 
     return (D,Dexch,Darr,DD)
 
@@ -54,36 +56,36 @@ demo2()
 Demonstrate higher level functions using smooth() and
 
 ```
-isdir("GRID_LLC90") ? demo1("LLC90") : GCMGridOnes("cs",6,100)
-(Rini,Rend,DXCsm,DYCsm)=demo2()
-@time Rend=smooth(Rini,DXCsm,DYCsm)
+(Rini,Rend,DXCsm,DYCsm)=demo2();
 
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_plot.jl"))
 qwckplot(Rini)
 qwckplot(Rend)
+@time Rend=smooth(Rini,DXCsm,DYCsm)
 ```
 
 """
 function demo2()
 
     #Pre-requisite: either load predefined grid using `demo1` or call `GCMGridOnes`
+    isdir("GRID_LLC90") ? mygrid=GCMGridLoad(GCMGridSpec("LLC90")) : mygrid=GCMGridOnes("cs",6,100)
 
     #initialize 2D field of random numbers
-    tmp1=convert2gcmfaces(MeshArrays.XC);
-    tmp1=randn(Float32,size(tmp1));
-    Rini=convert2gcmfaces(tmp1);
+    tmp1=convert2gcmfaces(mygrid["XC"])
+    tmp1=randn(Float32,size(tmp1))
+    Rini=convert2gcmfaces(tmp1)
 
     #apply land mask
-    if ndims(MeshArrays.hFacC.f[1])>2
-        tmp1=mask(view(MeshArrays.hFacC,:,:,1),NaN,0);
+    if ndims(mygrid["hFacC"].f[1])>2
+        tmp1=mask(view(mygrid["hFacC"],:,:,1),NaN,0)
     else
-        tmp1=mask(MeshArrays.hFacC,NaN,0);
+        tmp1=mask(mygrid["hFacC"],NaN,0)
     end
     msk=fill(1.,tmp1) + 0. *tmp1;
     Rini=msk*Rini;
 
     #specify smoothing length scales in x, y directions
-    DXCsm=3*MeshArrays.DXC; DYCsm=3*MeshArrays.DYC;
+    DXCsm=3*mygrid["DXC"]; DYCsm=3*mygrid["DYC"];
 
     #apply smoother
     Rend=smooth(Rini,DXCsm,DYCsm);
@@ -99,26 +101,33 @@ Demonstrate computations of ocean meridional transports. Calling sequence:
 
 ```
 !isdir("GRID_LLC90")||!isdir("nctiles_climatology") ? error("missing files") : nothing
-
-GCMGridSpec("LLC90")
-GCMGridLoad()
-
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_nctiles.jl"))
-fileName="nctiles_climatology/UVELMASS/UVELMASS"
-U=read_nctiles(fileName,"UVELMASS");
-fileName="nctiles_climatology/VVELMASS/VVELMASS"
-V=read_nctiles(fileName,"VVELMASS");
 
-(UV, LC, Tr)=demo3(U,V);
+(UV,LC,Tr)=demo3();
 
-using Statistics
+using Statistics, Plots
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_plot.jl"))
 qwckplot(UV["U"][:,:,1,1],"U component (note varying face orientations)")
 qwckplot(UV["V"][:,:,1,1],"V component (note varying face orientations)")
 plot(dropdims(mean(sum(Tr,dims=2),dims=3),dims=(2,3))/1e6,title="meridional transport")
 ```
 """
-function demo3(U,V)
+function demo3()
+
+    mygrid=GCMGridLoad(GCMGridSpec("LLC90"));
+
+    fileName="nctiles_climatology/UVELMASS/UVELMASS"
+    U=Main.read_nctiles(fileName,"UVELMASS");
+    fileName="nctiles_climatology/VVELMASS/VVELMASS"
+    V=Main.read_nctiles(fileName,"VVELMASS");
+
+    (UV, LC, Tr)=demo3(U,V);
+
+    return UV, LC, Tr
+
+end
+
+function demo3(U::gcmfaces,V::gcmfaces)
 
     LC=LatCircles(-89.0:89.0)
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -72,7 +72,7 @@ function demo2()
     (Rini,Rend,DXCsm,DYCsm)=demo2(mygrid)
 end
 
-function demo2(mygrid::Dict)
+function demo2(mygrid::gcmgrid)
 
     #initialize 2D field of random numbers
     tmp1=convert2gcmfaces(mygrid["XC"])
@@ -130,7 +130,7 @@ function demo3()
 
 end
 
-function demo3(U::gcmfaces,V::gcmfaces,mygrid::Dict)
+function demo3(U::gcmfaces,V::gcmfaces,mygrid::gcmgrid)
 
     LC=LatCircles(-89.0:89.0,mygrid)
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -16,7 +16,7 @@ function demo1(gridChoice)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=read_bin(mygrid["path"]*"Depth.data",mygrid["ioPrec"])
+    D=read_bin(mygrid.path*"Depth.data",mygrid.ioPrec)
 
     1000+D
     D+1000

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -33,7 +33,7 @@ function demo1(gridChoice)
 
     Dexch=exchange(D,4)
     Darr=convert2array(D)
-    DD=convert2array(Darr)
+    DD=convert2array(Darr,mygrid)
 
     mygrid=GCMGridLoad(mygrid)
 
@@ -77,7 +77,7 @@ function demo2(mygrid::Dict)
     #initialize 2D field of random numbers
     tmp1=convert2gcmfaces(mygrid["XC"])
     tmp1=randn(Float32,size(tmp1))
-    Rini=convert2gcmfaces(tmp1)
+    Rini=convert2gcmfaces(tmp1,mygrid)
 
     #apply land mask
     if ndims(mygrid["hFacC"].f[1])>2

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -16,7 +16,7 @@ function demo1(gridChoice)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=read_bin(mygrid.path*"Depth.data",mygrid.ioPrec)
+    D=read_bin(mygrid.path*"Depth.data",mygrid.ioPrec,mygrid)
 
     1000+D
     D+1000
@@ -37,7 +37,7 @@ function demo1(gridChoice)
 
     GridVariables=GCMGridLoad(mygrid)
 
-    (dFLDdx, dFLDdy)=gradient(GridVariables["YC"],mygrid)
+    (dFLDdx, dFLDdy)=gradient(GridVariables["YC"],GridVariables)
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
     view(GridVariables["hFacC"],:,:,40)
@@ -121,12 +121,13 @@ qwckplot(UV["V"][:,:,1,1],"V component (note varying face orientations)")
 """
 function demo3()
 
-    GridVariables=GCMGridLoad(GCMGridSpec("LLC90"));
+    mygrid=GCMGridSpec("LLC90")
+    GridVariables=GCMGridLoad(mygrid)
 
     fileName="nctiles_climatology/UVELMASS/UVELMASS"
-    U=Main.read_nctiles(fileName,"UVELMASS");
+    U=Main.read_nctiles(fileName,"UVELMASS",mygrid);
     fileName="nctiles_climatology/VVELMASS/VVELMASS"
-    V=Main.read_nctiles(fileName,"VVELMASS");
+    V=Main.read_nctiles(fileName,"VVELMASS",mygrid);
 
     (UV, LC, Tr)=demo3(U,V,GridVariables)
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -37,7 +37,7 @@ function demo1(gridChoice)
 
     mygrid=GCMGridLoad(mygrid)
 
-    (dFLDdx, dFLDdy)=gradient(mygrid["YC"])
+    (dFLDdx, dFLDdy)=gradient(mygrid["YC"],mygrid)
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
     view(mygrid["hFacC"],:,:,40)
@@ -61,7 +61,6 @@ Demonstrate higher level functions using smooth()
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_plot.jl"))
 qwckplot(Rini)
 qwckplot(Rend)
-@time Rend=smooth(Rini,DXCsm,DYCsm)
 ```
 
 """
@@ -93,7 +92,7 @@ function demo2(mygrid::Dict)
     DXCsm=3*mygrid["DXC"]; DYCsm=3*mygrid["DYC"];
 
     #apply smoother
-    Rend=smooth(Rini,DXCsm,DYCsm);
+    Rend=smooth(Rini,DXCsm,DYCsm,mygrid);
 
     return (Rini,Rend,DXCsm,DYCsm)
 
@@ -127,13 +126,13 @@ function demo3()
     fileName="nctiles_climatology/VVELMASS/VVELMASS"
     V=Main.read_nctiles(fileName,"VVELMASS");
 
-    (UV, LC, Tr)=demo3(U,V)
+    (UV, LC, Tr)=demo3(U,V,mygrid)
 
 end
 
-function demo3(U::gcmfaces,V::gcmfaces)
+function demo3(U::gcmfaces,V::gcmfaces,mygrid::Dict)
 
-    LC=LatCircles(-89.0:89.0)
+    LC=LatCircles(-89.0:89.0,mygrid)
 
     U=mask(U,0.0)
     V=mask(V,0.0)
@@ -143,7 +142,7 @@ function demo3(U::gcmfaces,V::gcmfaces)
     n=size(U)
     Tr=Array{Float64}(undef,length(LC),n[3],n[4])
     for i=1:length(LC)
-        Tr[i,:,:]=TransportThrough(UV,LC[i])
+        Tr[i,:,:]=TransportThrough(UV,LC[i],mygrid)
     end
 
     return UV, LC, Tr

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -16,7 +16,7 @@ function demo1(gridChoice)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=read_bin(mygrid["grDir"]*"Depth.data",mygrid["ioPrec"])
+    D=read_bin(mygrid["path"]*"Depth.data",mygrid["ioPrec"])
 
     1000+D
     D+1000

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -4,7 +4,7 @@
 """
 demo1(gridChoice)
 
-Demonstrate basic fucntions (arithmetic, exchange, GCMGridLoad, gradient, etc.). Example call:
+Demonstrate basic functionalities (load grid, arithmetic, exchange, gradient, etc.)
 
 ```
 !isdir("GRID_LLC90") ? error("missing files") : nothing
@@ -53,7 +53,7 @@ end
 """
 demo2()
 
-Demonstrate higher level functions using smooth() and
+Demonstrate higher level functions using smooth()
 
 ```
 (Rini,Rend,DXCsm,DYCsm)=demo2();
@@ -69,6 +69,11 @@ function demo2()
 
     #Pre-requisite: either load predefined grid using `demo1` or call `GCMGridOnes`
     isdir("GRID_LLC90") ? mygrid=GCMGridLoad(GCMGridSpec("LLC90")) : mygrid=GCMGridOnes("cs",6,100)
+
+    (Rini,Rend,DXCsm,DYCsm)=demo2(mygrid)
+end
+
+function demo2(mygrid::Dict)
 
     #initialize 2D field of random numbers
     tmp1=convert2gcmfaces(mygrid["XC"])
@@ -106,10 +111,11 @@ include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_nctiles.jl"))
 (UV,LC,Tr)=demo3();
 
 using Statistics, Plots
+plot(dropdims(mean(sum(Tr,dims=2),dims=3),dims=(2,3))/1e6,title="meridional transport")
+
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_plot.jl"))
 qwckplot(UV["U"][:,:,1,1],"U component (note varying face orientations)")
 qwckplot(UV["V"][:,:,1,1],"V component (note varying face orientations)")
-plot(dropdims(mean(sum(Tr,dims=2),dims=3),dims=(2,3))/1e6,title="meridional transport")
 ```
 """
 function demo3()
@@ -121,9 +127,7 @@ function demo3()
     fileName="nctiles_climatology/VVELMASS/VVELMASS"
     V=Main.read_nctiles(fileName,"VVELMASS");
 
-    (UV, LC, Tr)=demo3(U,V);
-
-    return UV, LC, Tr
+    (UV, LC, Tr)=demo3(U,V)
 
 end
 

--- a/src/gcmfaces_exch.jl
+++ b/src/gcmfaces_exch.jl
@@ -35,11 +35,11 @@ end
 
 function exch_T_N(fld,N)
 
-if fld.grTopo=="llc";
+if fld.grid["grTopo"]=="llc";
   FLD=exch_T_N_cs(fld,N);
-elseif fld.grTopo=="cs";
+elseif fld.grid["grTopo"]=="cs";
   FLD=exch_T_N_cs(fld,N);
-elseif fld.grTopo=="ll";
+elseif fld.grid["grTopo"]=="ll";
   FLD=exch_T_N_ll(fld,N);
 else;
   error("unknown grTopo case");
@@ -51,11 +51,11 @@ end
 
 function exch_UV_N(u,v,N)
 
-if u.grTopo=="llc";
+if u.grid["grTopo"]=="llc";
   (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grTopo=="cs";
+elseif u.grid["grTopo"]=="cs";
   (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grTopo=="ll";
+elseif u.grid["grTopo"]=="ll";
   (uex,vex)=exch_UV_N_ll(u,v,N);
 else;
   error("unknown grTopo case");
@@ -67,11 +67,11 @@ end
 
 function exch_UV(u,v)
 
-if u.grTopo=="llc";
+if u.grid["grTopo"]=="llc";
   (uex,vex)=exch_UV_cs(u,v);
-elseif u.grTopo=="cs";
+elseif u.grid["grTopo"]=="cs";
   (uex,vex)=exch_UV_cs(u,v);
-elseif u.grTopo=="ll";
+elseif u.grid["grTopo"]=="ll";
   (uex,vex)=exch_UV_ll(u,v);
 else;
   error("unknown grTopo case");
@@ -154,9 +154,9 @@ fillval=0.0
 #step 1
 
 s=size.(fld.f);
-nf=fld.nFaces;
+nf=fld.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fld.grTopo;
+tp=fld.grid["grTopo"];
 FLD=similar(fld);
 
 for i=1:nf; FLD.f[i]=fill(fillval,s[i].+2N); end;
@@ -202,9 +202,9 @@ fillval=0.0
 #step 1
 
 s=size.(fldU.f);
-nf=fldU.nFaces;
+nf=fldU.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grTopo;
+tp=fldU.grid["grTopo"];
 FLDU=similar(fldU);
 FLDV=similar(fldV);
 
@@ -256,9 +256,9 @@ fillval=0.0
 #step 1
 
 s=size.(fldU.f);
-nf=fldU.nFaces;
+nf=fldU.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grTopo;
+tp=fldU.grid["grTopo"];
 FLDU=similar(fldU);
 FLDV=similar(fldV);
 

--- a/src/gcmfaces_exch.jl
+++ b/src/gcmfaces_exch.jl
@@ -35,15 +35,15 @@ end
 
 function exch_T_N(fld,N)
 
-if fld.grid["class"]=="llc";
-  FLD=exch_T_N_cs(fld,N);
-elseif fld.grid["class"]=="cs";
-  FLD=exch_T_N_cs(fld,N);
-elseif fld.grid["class"]=="ll";
-  FLD=exch_T_N_ll(fld,N);
-else;
-  error("unknown grTopo case");
-end;
+if fld.grid.class=="llc"
+  FLD=exch_T_N_cs(fld,N)
+elseif fld.grid.class=="cs"
+  FLD=exch_T_N_cs(fld,N)
+elseif fld.grid.class=="ll"
+  FLD=exch_T_N_ll(fld,N)
+else
+  error("unknown grTopo case")
+end
 
 FLD
 
@@ -51,15 +51,15 @@ end
 
 function exch_UV_N(u,v,N)
 
-if u.grid["class"]=="llc";
-  (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grid["class"]=="cs";
-  (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grid["class"]=="ll";
-  (uex,vex)=exch_UV_N_ll(u,v,N);
-else;
-  error("unknown grTopo case");
-end;
+if u.grid.class=="llc"
+  (uex,vex)=exch_UV_N_cs(u,v,N)
+elseif u.grid.class=="cs"
+  (uex,vex)=exch_UV_N_cs(u,v,N)
+elseif u.grid.class=="ll"
+  (uex,vex)=exch_UV_N_ll(u,v,N)
+else
+  error("unknown grTopo case")
+end
 
 return uex,vex
 
@@ -67,15 +67,15 @@ end
 
 function exch_UV(u,v)
 
-if u.grid["class"]=="llc";
-  (uex,vex)=exch_UV_cs(u,v);
-elseif u.grid["class"]=="cs";
-  (uex,vex)=exch_UV_cs(u,v);
-elseif u.grid["class"]=="ll";
-  (uex,vex)=exch_UV_ll(u,v);
-else;
-  error("unknown grTopo case");
-end;
+if u.grid.class=="llc"
+  (uex,vex)=exch_UV_cs(u,v)
+elseif u.grid.class=="cs"
+  (uex,vex)=exch_UV_cs(u,v)
+elseif u.grid.class=="ll"
+  (uex,vex)=exch_UV_ll(u,v)
+else
+  error("unknown grTopo case")
+end
 
 return uex,vex
 
@@ -153,11 +153,11 @@ fillval=0.0
 
 #step 1
 
-s=size.(fld.f);
-nf=fld.grid["nFaces"];
+s=size.(fld.f)
+nf=fld.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fld.grid["class"];
-FLD=similar(fld);
+tp=fld.grid.class
+FLD=similar(fld)
 
 for i=1:nf; FLD.f[i]=fill(fillval,s[i].+2N); end;
 #code below yields strange, seemingly incorrect results:
@@ -201,12 +201,12 @@ fillval=0.0
 
 #step 1
 
-s=size.(fldU.f);
-nf=fldU.grid["nFaces"];
+s=size.(fldU.f)
+nf=fldU.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grid["class"];
-FLDU=similar(fldU);
-FLDV=similar(fldV);
+tp=fldU.grid.class
+FLDU=similar(fldU)
+FLDV=similar(fldV)
 
 for i=1:nf;
  FLDU.f[i]=fill(fillval,s[i].+2N);
@@ -255,12 +255,12 @@ fillval=0.0
 
 #step 1
 
-s=size.(fldU.f);
-nf=fldU.grid["nFaces"];
+s=size.(fldU.f)
+nf=fldU.grid.nFaces
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grid["class"];
-FLDU=similar(fldU);
-FLDV=similar(fldV);
+tp=fldU.grid.class
+FLDU=similar(fldU)
+FLDV=similar(fldV)
 
 for i=1:nf
   FLDU.f[i]=fill(fillval,s[i][1]+1,s[i][2]);

--- a/src/gcmfaces_exch.jl
+++ b/src/gcmfaces_exch.jl
@@ -35,11 +35,11 @@ end
 
 function exch_T_N(fld,N)
 
-if fld.grid["grTopo"]=="llc";
+if fld.grid["class"]=="llc";
   FLD=exch_T_N_cs(fld,N);
-elseif fld.grid["grTopo"]=="cs";
+elseif fld.grid["class"]=="cs";
   FLD=exch_T_N_cs(fld,N);
-elseif fld.grid["grTopo"]=="ll";
+elseif fld.grid["class"]=="ll";
   FLD=exch_T_N_ll(fld,N);
 else;
   error("unknown grTopo case");
@@ -51,11 +51,11 @@ end
 
 function exch_UV_N(u,v,N)
 
-if u.grid["grTopo"]=="llc";
+if u.grid["class"]=="llc";
   (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grid["grTopo"]=="cs";
+elseif u.grid["class"]=="cs";
   (uex,vex)=exch_UV_N_cs(u,v,N);
-elseif u.grid["grTopo"]=="ll";
+elseif u.grid["class"]=="ll";
   (uex,vex)=exch_UV_N_ll(u,v,N);
 else;
   error("unknown grTopo case");
@@ -67,11 +67,11 @@ end
 
 function exch_UV(u,v)
 
-if u.grid["grTopo"]=="llc";
+if u.grid["class"]=="llc";
   (uex,vex)=exch_UV_cs(u,v);
-elseif u.grid["grTopo"]=="cs";
+elseif u.grid["class"]=="cs";
   (uex,vex)=exch_UV_cs(u,v);
-elseif u.grid["grTopo"]=="ll";
+elseif u.grid["class"]=="ll";
   (uex,vex)=exch_UV_ll(u,v);
 else;
   error("unknown grTopo case");
@@ -156,7 +156,7 @@ fillval=0.0
 s=size.(fld.f);
 nf=fld.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fld.grid["grTopo"];
+tp=fld.grid["class"];
 FLD=similar(fld);
 
 for i=1:nf; FLD.f[i]=fill(fillval,s[i].+2N); end;
@@ -204,7 +204,7 @@ fillval=0.0
 s=size.(fldU.f);
 nf=fldU.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grid["grTopo"];
+tp=fldU.grid["class"];
 FLDU=similar(fldU);
 FLDV=similar(fldV);
 
@@ -258,7 +258,7 @@ fillval=0.0
 s=size.(fldU.f);
 nf=fldU.grid["nFaces"];
 nf==5 ? s=vcat(s,s[3]) : nothing
-tp=fldU.grid["grTopo"];
+tp=fldU.grid["class"];
 FLDU=similar(fldU);
 FLDV=similar(fldV);
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -8,12 +8,11 @@ GCMGridSpec() = GCMGridSpec("LLC90")
 """
     GCMGridSpec(gridName)
 
-Set global variables in the module scope for grDir, nFaces, grTopo, ioSize,
-facesSize, ioPrec using hard-coded values for LLC90, CS32, LL360 (for now).
+Return a `gmcgrid` specification that provides grid files path,
+class, nFaces, ioSize, facesSize, ioPrec, & a read function (not
+yet) using hard-coded values for LLC90, CS32, LL360 (for now).
 """
 function GCMGridSpec(gridName,gridParentDir="./")
-
-global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
 
 if gridName=="LLC90";
     grDir=gridParentDir*"GRID_LLC90/";
@@ -51,17 +50,12 @@ end
 """
     GCMGridLoad(mygrid::gcmgrid)
 
-Loads grid variables from files located in grDir set by GCMGridSpec.
+Return a `Dict` of grid variables from files located in mygrid.path (see `GCMGridSpec`).
 
-Grid variables are XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC,
+Grid variables are named XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC,
 hFacS, hFacW, Depth based on the MITgcm naming convention.
 """
 function GCMGridLoad(mygrid::gcmgrid)
-
-    #maybe just return as a dictionnary?
-    global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth
-    global AngleCS, AngleSN, RAW, RAS
-    global DRC, DRF, RC, RF
 
     GridVariables=Dict()
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
@@ -102,9 +96,6 @@ Define all-1 grid variables instead of using GCMGridSpec & GCMGridLoad.
 """
 function GCMGridOnes(grTp,nF,nP)
 
-    global grDir, nFaces, grTopo, ioSize, facesSize, ioPrec;
-    global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth;
-
     grDir=""
     grTopo=grTp
     nFaces=nF
@@ -130,19 +121,25 @@ function GCMGridOnes(grTp,nF,nP)
 end
 
 
-function findtiles(ni,nj,grid="llc90")
+"""
+    findtiles(ni,nj,grid="llc90")
+
+Return a `gcmfaces` map of tile indices for tile size (ni,nj)
+"""
+function findtiles(ni::Int,nj::Int,grid="llc90")
     mytiles = Dict()
     if grid=="llc90"
-        GCMGridLoad()
+        mygrid=GCMGridSpec("LLC90")
+        GridVariables=GCMGridLoad(mygrid)
     else
         println("Unsupported grid option")
     end
-    mytiles["nFaces"]=MeshArrays.nFaces;
+    mytiles["nFaces"]=mygrid.nFaces;
     #mytiles.fileFormat=mygrid.fileFormat;
-    mytiles["ioSize"]=MeshArrays.ioSize;
+    mytiles["ioSize"]=mygrid.ioSize;
 
-    XC=MeshArrays.XC;
-    YC=MeshArrays.YC;
+    XC=GridVariables["XC"];
+    YC=GridVariables["YC"];
     XC11=copy(XC); YC11=copy(XC);
     XCNINJ=copy(XC); YCNINJ=copy(XC);
     iTile=copy(XC); jTile=copy(XC); tileNo=copy(XC);

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -66,22 +66,22 @@ function GCMGridLoad(mygrid::gcmgrid)
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth")
     for ii=1:length(list0);
-        tmp1=read_bin(mygrid["path"]*list0[ii]*".data",mygrid["ioPrec"]);
+        tmp1=read_bin(mygrid.path*list0[ii]*".data",mygrid.ioPrec);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         mygrid[list0[ii]]=tmp1
     end
 
-    mygrid["ioPrec"]==Float64 ? reclen=8 : reclen=4
+    mygrid.ioPrec==Float64 ? reclen=8 : reclen=4
 
     list0=("DRC","DRF","RC","RF")
     for ii=1:length(list0)
-        fil=mygrid["path"]*list0[ii]*".data"
+        fil=mygrid.path*list0[ii]*".data"
         tmp1=stat(fil)
         n3=Int64(tmp1.size/reclen) #need fix for float32?
 
         fid = open(fil)
-        tmp1 = Array{mygrid["ioPrec"],1}(undef,n3)  #need fix for float32?
+        tmp1 = Array{mygrid.ioPrec,1}(undef,n3)  #need fix for float32?
         read!(fid,tmp1)
         tmp1 = hton.(tmp1)
 
@@ -145,7 +145,7 @@ function findtiles(ni,nj,grid="llc90")
     XCNINJ=copy(XC); YCNINJ=copy(XC);
     iTile=copy(XC); jTile=copy(XC); tileNo=copy(XC);
     tileCount=0;
-    for iF=1:XC11.grid["nFaces"]
+    for iF=1:XC11.grid.nFaces
         #global tileCount,XC,YC,XC11,YC11,iTile,jTile,tileNo
         face_XC=XC.f[iF]; face_YC=YC.f[iF];
     #ordering convention that was used in first generation nctile files:

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -66,9 +66,9 @@ function GCMGridLoad(mygrid::gcmgrid)
     GridVariables=Dict()
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth")
-    for ii=1:length(list0);
-        tmp1=read_bin(mygrid.path*list0[ii]*".data",mygrid.ioPrec);
-        tmp2=Symbol(list0[ii]);
+    for ii=1:length(list0)
+        tmp1=read_bin(mygrid.path*list0[ii]*".data",mygrid.ioPrec,mygrid)
+        tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
     end
@@ -79,10 +79,10 @@ function GCMGridLoad(mygrid::gcmgrid)
     for ii=1:length(list0)
         fil=mygrid.path*list0[ii]*".data"
         tmp1=stat(fil)
-        n3=Int64(tmp1.size/reclen) #need fix for float32?
+        n3=Int64(tmp1.size/reclen)
 
         fid = open(fil)
-        tmp1 = Array{mygrid.ioPrec,1}(undef,n3)  #need fix for float32?
+        tmp1 = Array{mygrid.ioPrec,1}(undef,n3)
         read!(fid,tmp1)
         tmp1 = hton.(tmp1)
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -40,7 +40,7 @@ else;
     error("unknown gridName case");
 end;
 
-mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> x)
+mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> missing)
 
 return mygrid
 
@@ -63,13 +63,14 @@ function GCMGridLoad(mygrid::gcmgrid)
     global AngleCS, AngleSN, RAW, RAS
     global DRC, DRF, RC, RF
 
+    GridVariables=Dict()
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth")
     for ii=1:length(list0);
         tmp1=read_bin(mygrid.path*list0[ii]*".data",mygrid.ioPrec);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
-        mygrid[list0[ii]]=tmp1
+        GridVariables[list0[ii]]=tmp1
     end
 
     mygrid.ioPrec==Float64 ? reclen=8 : reclen=4
@@ -87,10 +88,10 @@ function GCMGridLoad(mygrid::gcmgrid)
 
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
-        mygrid[list0[ii]]=tmp1
+        GridVariables[list0[ii]]=tmp1
     end
 
-    return mygrid
+    return GridVariables
 
 end
 
@@ -112,18 +113,19 @@ function GCMGridOnes(grTp,nF,nP)
     facesSize[:].=[(nP,nP)]
     ioPrec=Float32
 
-    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec)
+    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> missing)
 
+    GridVariables=Dict()
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
         tmp1=convert2gcmfaces(tmp1,mygrid);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
-        mygrid[list0[ii]]=tmp1
+        GridVariables[list0[ii]]=tmp1
     end
 
-    return mygrid
+    return GridVariables
 
 end
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -144,7 +144,7 @@ function findtiles(ni,nj,grid="llc90")
     XCNINJ=copy(XC); YCNINJ=copy(XC);
     iTile=copy(XC); jTile=copy(XC); tileNo=copy(XC);
     tileCount=0;
-    for iF=1:XC11.nFaces;
+    for iF=1:XC11.grid["nFaces"]
         #global tileCount,XC,YC,XC11,YC11,iTile,jTile,tileNo
         face_XC=XC.f[iF]; face_YC=YC.f[iF];
     #ordering convention that was used in first generation nctile files:

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -40,8 +40,8 @@ else;
     error("unknown gridName case");
 end;
 
-mygrid=Dict("path" => grDir, "class" => grTopo, "nFaces" => nFaces,
-    "fSize" => facesSize, "ioSize" => ioSize, "ioPrec" => ioPrec)
+mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> x)
+
 return mygrid
 
 end
@@ -49,14 +49,14 @@ end
 ## GCMGridLoad function
 
 """
-    GCMGridLoad(mygrid::Dict)
+    GCMGridLoad(mygrid::gcmgrid)
 
 Loads grid variables from files located in grDir set by GCMGridSpec.
 
 Grid variables are XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC,
 hFacS, hFacW, Depth based on the MITgcm naming convention.
 """
-function GCMGridLoad(mygrid::Dict=Dict())
+function GCMGridLoad(mygrid::gcmgrid)
 
     #maybe just return as a dictionnary?
     global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth
@@ -112,8 +112,7 @@ function GCMGridOnes(grTp,nF,nP)
     facesSize[:].=[(nP,nP)]
     ioPrec=Float32
 
-    mygrid=Dict("path" => grDir, "class" => grTopo, "nFaces" => nFaces,
-        "fSize" => facesSize, "ioSize" => ioSize, "ioPrec" => ioPrec)
+    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec)
 
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -116,7 +116,7 @@ function GCMGridOnes(grTp,nF,nP)
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=convert2gcmfaces(tmp1);
+        tmp1=convert2gcmfaces(tmp1,mygrid);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         mygrid[list0[ii]]=tmp1

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -40,21 +40,23 @@ else;
     error("unknown gridName case");
 end;
 
-return "GCMGridSpec: passed"
+mygrid=Dict("grDir" => grDir, "nFaces" => nFaces, "grTopo" => grTopo,
+    "ioSize" => ioSize, "facesSize" => facesSize, "ioPrec" => ioPrec)
+return mygrid
 
 end
 
 ## GCMGridLoad function
 
 """
-    GCMGridLoad()
+    GCMGridLoad(mygrid::Dict)
 
 Loads grid variables from files located in grDir set by GCMGridSpec.
 
 Grid variables are XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC,
 hFacS, hFacW, Depth based on the MITgcm naming convention.
 """
-function GCMGridLoad()
+function GCMGridLoad(mygrid::Dict=Dict())
 
     #maybe just return as a dictionnary?
     global XC, XG, YC, YG, RAC, RAZ, DXC, DXG, DYC, DYG, hFacC, hFacS, hFacW, Depth
@@ -67,6 +69,7 @@ function GCMGridLoad()
         tmp1=read_bin(grDir*list0[ii]*".data",ioPrec);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
+        mygrid[list0[ii]]=tmp1
     end
 
     list0=("DRC","DRF","RC","RF")
@@ -82,9 +85,10 @@ function GCMGridLoad()
 
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
+        mygrid[list0[ii]]=tmp1
     end
 
-    return "GCMGridLoad: passed"
+    return mygrid
 
 end
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -110,15 +110,19 @@ function GCMGridOnes(grTp,nF,nP)
     facesSize[:].=[(nP,nP)]
     ioPrec=Float32
 
+    mygrid=Dict("grDir" => grDir, "nFaces" => nFaces, "grTopo" => grTopo,
+        "ioSize" => ioSize, "facesSize" => facesSize, "ioPrec" => ioPrec)
+
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
         tmp1=convert2gcmfaces(tmp1);
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
+        mygrid[list0[ii]]=tmp1
     end
 
-    return "GCMGridOnes: passed"
+    return mygrid
 
 end
 

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -21,7 +21,7 @@ if ~(MeshArrays.grTopo=="llc");
   error("non-llc cases not implemented yet");
 end;
 
-grid=Dict("nFaces"=>5,"grTopo"=>"llc")
+grid=Dict("nFaces"=>5,"class"=>"llc")
 
 fileIn=@sprintf("%s.%04d.nc",fileName,1);
 x = ncread(fileIn,fldName);

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -21,6 +21,8 @@ if ~(MeshArrays.grTopo=="llc");
   error("non-llc cases not implemented yet");
 end;
 
+grid=Dict("nFaces"=>5,"grTopo"=>"llc")
+
 fileIn=@sprintf("%s.%04d.nc",fileName,1);
 x = ncread(fileIn,fldName);
 ndims=length(size(x));
@@ -59,7 +61,7 @@ for ff=1:13;
 end;
 
 #return f gcmfaces object fld
-fld=gcmfaces(5,"llc",f)
+fld=gcmfaces(grid,f)
 return fld
 
 end

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -21,7 +21,8 @@ if ~(MeshArrays.grTopo=="llc");
   error("non-llc cases not implemented yet");
 end;
 
-grid=Dict("nFaces"=>5,"class"=>"llc")
+fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
+grid=gcmgrid("", "llc", 5, fSize, [90 1170], Float64, x -> x)
 
 fileIn=@sprintf("%s.%04d.nc",fileName,1);
 x = ncread(fileIn,fldName);

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -6,23 +6,21 @@ export read_nctiles
 ## read_nctiles function
 #
 #examples:
+#  mygrid=GCMGridSpec("LLC90")
 #  fileName="nctiles_grid/GRID"
-#  Depth=read_nctiles(fileName,"Depth")
-#  hFacC=read_nctiles(fileName,"hFacC")
+#  Depth=read_nctiles(fileName,"Depth",mygrid)
+#  hFacC=read_nctiles(fileName,"hFacC",mygrid)
 
 """
-    read_nctiles(fileName,fldName)
+    read_nctiles(fileName,fldName,mygrid)
 
 Read model output from Netcdf / NCTiles file and convert to gcmfaces structure.
 """
-function read_nctiles(fileName,fldName)
+function read_nctiles(fileName::String,fldName::String,mygrid::gcmgrid)
 
-if ~(MeshArrays.grTopo=="llc");
-  error("non-llc cases not implemented yet");
+if (mygrid.class!="llc")||(mygrid.ioSize!=[90 1170])
+  error("non-llc90 cases not implemented yet");
 end;
-
-fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
-grid=gcmgrid("", "llc", 5, fSize, [90 1170], Float64, x -> missing)
 
 fileIn=@sprintf("%s.%04d.nc",fileName,1);
 x = ncread(fileIn,fldName);
@@ -62,7 +60,7 @@ for ff=1:13;
 end;
 
 #return f gcmfaces object fld
-fld=gcmfaces(grid,f)
+fld=gcmfaces(mygrid,f)
 return fld
 
 end

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -22,7 +22,7 @@ if ~(MeshArrays.grTopo=="llc");
 end;
 
 fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
-grid=gcmgrid("", "llc", 5, fSize, [90 1170], Float64, x -> x)
+grid=gcmgrid("", "llc", 5, fSize, [90 1170], Float64, x -> missing)
 
 fileIn=@sprintf("%s.%04d.nc",fileName,1);
 x = ncread(fileIn,fldName);

--- a/src/gcmfaces_plot.jl
+++ b/src/gcmfaces_plot.jl
@@ -12,8 +12,8 @@ Call qwckplot(fld::gcmfaces,ttl::String) with current date for title. Example:
 
 ```
 !isdir("GRID_LLC90") ? error("missing files") : nothing
-mygrid=GCMGridLoad(GCMGridSpec("LLC90"))
-qwckplot(mygrid["Depth"])
+GridVariables=GCMGridLoad(GCMGridSpec("LLC90"))
+qwckplot(GridVariables["Depth"])
 ```
 """
 function qwckplot(fld::gcmfaces)

--- a/src/gcmfaces_plot.jl
+++ b/src/gcmfaces_plot.jl
@@ -4,16 +4,17 @@ using Plots, Dates; gr();
 export qwckplot
 
 ##  qwckplot function
-#
-#examples:
-#  GCMGridLoad()
-#  qwckplot(MeshArrays.Depth)
-#  qwckplot(MeshArrays.Depth,"Ocean Bottom Depth")
 
 """
     qwckplot(fld::gcmfaces)
 
-Call qwckplot(fld::gcmfaces,ttl::String) with current date for title
+Call qwckplot(fld::gcmfaces,ttl::String) with current date for title. Example:
+
+```
+!isdir("GRID_LLC90") ? error("missing files") : nothing
+mygrid=GCMGridLoad(GCMGridSpec("LLC90"))
+qwckplot(mygrid["Depth"])
+```
 """
 function qwckplot(fld::gcmfaces)
     tmp1=Dates.now()

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -7,7 +7,7 @@ abstract type AbstractGcmfaces{T, N} <: AbstractArray{T, N} end
 """
     gcmgrid
 
-gcmsubset data structure. Available constructors?
+gcmgrid data structure. Available constructors?
 
 """
 struct gcmgrid
@@ -105,7 +105,7 @@ function gcmfaces()
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
   aSize=(105300, 1)
-  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, x -> x)
+  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, x -> missing)
 
   gcmfaces(grid,T,fSize,aSize)
 end

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -79,13 +79,13 @@ end
 
 function gcmfaces(grid::Dict)
   T=grid["ioPrec"]
-  fSize=grid["facesSize"]
+  fSize=grid["fSize"]
   aSize=(prod(grid["ioSize"]),1)
   gcmfaces(grid,T,fSize,aSize)
 end
 
 function gcmfaces()
-  grid=Dict("nFaces"=>5, "grTopo"=>"llc")
+  grid=Dict("nFaces"=>5, "class"=>"llc")
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
   aSize=(105300, 1);
@@ -256,7 +256,7 @@ end
 
 function Base.view(a::AbstractGcmfaces{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
   nFaces=a.grid["nFaces"]
-  grTopo=a.grid["grTopo"]
+  grTopo=a.grid["class"]
   if !isa(I[1],Colon)|!isa(I[2],Colon)
     J=Base.tail(Base.tail(I))
     J=(:,:,J...)
@@ -289,7 +289,7 @@ function Base.show(io::IO, z::AbstractGcmfaces{T, N}) where {T,N}
       error("unknown type")
     end
     printstyled(io, "  grid type   = ",color=:normal)
-    printstyled(io, "$(z.grid["grTopo"])\n",color=:blue)
+    printstyled(io, "$(z.grid["class"])\n",color=:blue)
     printstyled(io, "  # of faces  = ",color=:normal)
     printstyled(io, "$(z.grid["nFaces"])\n",color=:blue)
     if ~isassigned(z.f);

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -7,8 +7,13 @@ abstract type AbstractGcmfaces{T, N} <: AbstractArray{T, N} end
 """
     gcmgrid
 
-gcmgrid data structure. Available constructors?
+gcmgrid data structure. Available constructors:
 
+```
+gcmgrid(path::String, class::String, nFaces::Int,
+        fSize::Array{NTuple{2, Int},1}, ioSize::Array{Int64,2},
+        ioPrec::Type, read::Function)
+```
 """
 struct gcmgrid
   path::String

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -71,7 +71,7 @@ end
 function gcmfaces(grid::gcmgrid,::Type{T},
   fSize::Array{NTuple{N, Int}},
   aSize::NTuple{N,Int}) where {T,N}
-  nFaces=grid["nFaces"]
+  nFaces=grid.nFaces
   f=Array{Array{T,N},1}(undef,nFaces)
   for a=1:nFaces
     f[a]=Array{T}(undef,fSize[a])
@@ -95,9 +95,9 @@ function gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
 end
 
 function gcmfaces(grid::gcmgrid)
-  T=grid["ioPrec"]
-  fSize=grid["fSize"]
-  aSize=(prod(grid["ioSize"]),1)
+  T=grid.ioPrec
+  fSize=grid.fSize
+  aSize=(prod(grid.ioSize),1)
   gcmfaces(grid,T,fSize,aSize)
 end
 
@@ -116,7 +116,7 @@ end
 function gcmsubset(grid::gcmgrid,::Type{T},
   fSize::Array{NTuple{N, Int}},aSize::NTuple{N,Int},
   dims::NTuple{N,Int}) where {T,N}
-  nFaces=grid["nFaces"]
+  nFaces=grid.nFaces
   f=Array{Array{T,N},1}(undef,nFaces)
   i=Array{Array{T,N},1}(undef,nFaces)
   iSize=Array{NTuple{N, Int},1}(undef,nFaces)
@@ -143,7 +143,7 @@ function fijind(A::gcmfaces,ij::Int)
   j=0
   k=0
   tmp1=0
-  for iFace=1:A.grid["nFaces"]
+  for iFace=1:A.grid.nFaces
     tmpsize=fsize(A,iFace)
     tmp11=tmpsize[1]*tmpsize[2]
     tmp2=tmp1+tmp11
@@ -169,8 +169,8 @@ fsize(A::Array{Array{T,N},1},i::Int) where {T,N}
 ```
 """
 function fsize(A::AbstractGcmfaces{T, N}) where {T,N}
-  fs=Array{NTuple{N, Int}}(undef,A.grid["nFaces"])
-  for i=1:A.grid["nFaces"]
+  fs=Array{NTuple{N, Int}}(undef,A.grid.nFaces)
+  for i=1:A.grid.nFaces
     fs[i]=size(A.f[i]);
   end
   return fs
@@ -181,7 +181,7 @@ function fsize(A::AbstractGcmfaces{T, N},i::Int) where {T,N}
     fs=size(A.f[i])
   else
     tmp1=0
-    for i=1:A.grid["nFaces"]
+    for i=1:A.grid.nFaces
       tmp1=tmp1+size(A.f[i],1)*size(A.f[i],2)
     end
     tmp2=size(A.f[1])
@@ -227,7 +227,7 @@ function Base.getindex(A::AbstractGcmfaces{T, N}, I::Vararg{Union{Int,AbstractUn
     val=A.f[f][J...]
   elseif typeof(I[1])<:AbstractUnitRange
     val=similar(A,eltype(A),length.(I))
-    for iFace=1:A.grid["nFaces"]
+    for iFace=1:A.grid.nFaces
       @views val.f[iFace]=A.f[iFace]
     end
     #eventually I will distribute across faces; for now I just use face 1:
@@ -273,8 +273,8 @@ end
 ## view
 
 function Base.view(a::AbstractGcmfaces{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
-  nFaces=a.grid["nFaces"]
-  grTopo=a.grid["class"]
+  nFaces=a.grid.nFaces
+  grTopo=a.grid.class
   if !isa(I[1],Colon)|!isa(I[2],Colon)
     J=Base.tail(Base.tail(I))
     J=(:,:,J...)
@@ -307,9 +307,9 @@ function Base.show(io::IO, z::AbstractGcmfaces{T, N}) where {T,N}
       error("unknown type")
     end
     printstyled(io, "  grid type   = ",color=:normal)
-    printstyled(io, "$(z.grid["class"])\n",color=:blue)
+    printstyled(io, "$(z.grid.class)\n",color=:blue)
     printstyled(io, "  # of faces  = ",color=:normal)
-    printstyled(io, "$(z.grid["nFaces"])\n",color=:blue)
+    printstyled(io, "$(z.grid.nFaces)\n",color=:blue)
     if ~isassigned(z.f);
       printstyled(io, "  data type   = ",color=:normal)
       printstyled(io, "unassigned\n",color=:green)
@@ -320,7 +320,7 @@ function Base.show(io::IO, z::AbstractGcmfaces{T, N}) where {T,N}
       printstyled(io, "$(typeof(z.f[1][1]))\n",color=:blue)
       printstyled(io, "  $(nm) sizes  = ",color=:normal)
       printstyled(io, "$(fs[1])\n",color=:blue)
-      for iFace=2:z.grid["nFaces"]
+      for iFace=2:z.grid.nFaces
         printstyled(io, "                ",color=:normal)
         printstyled(io, "$(fs[iFace])\n",color=:blue)
       end
@@ -383,7 +383,7 @@ import Base: maximum, minimum, sum, fill
 
 function +(a::gcmfaces)
   c=similar(a)
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=+a.f[iFace];
   end
   return c
@@ -391,7 +391,7 @@ end
 
 function +(a::gcmfaces,b::gcmfaces)
   c=similar(a)
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace]+b.f[iFace];
   end
   return c
@@ -405,7 +405,7 @@ end
 
 function +(a::Number,b::gcmfaces)
   c=similar(b)
-  for iFace=1:b.grid["nFaces"]
+  for iFace=1:b.grid.nFaces
     c.f[iFace]=a.+b.f[iFace];
   end
   return c
@@ -421,7 +421,7 @@ end
 
 function -(a::gcmfaces)
   c=similar(a)
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=-a.f[iFace];
   end
   return c
@@ -429,7 +429,7 @@ end
 
 function -(a::gcmfaces,b::gcmfaces)
   c=similar(a)
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace]-b.f[iFace];
   end
   return c
@@ -437,7 +437,7 @@ end
 
 function -(a::Number,b::gcmfaces)
   c=similar(b)
-  for iFace=1:b.grid["nFaces"]
+  for iFace=1:b.grid.nFaces
     c.f[iFace]=a.-b.f[iFace];
   end
   return c
@@ -445,7 +445,7 @@ end
 
 function -(a::gcmfaces,b::Number)
   c=similar(a)
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace].-b;
   end
   return c
@@ -453,7 +453,7 @@ end
 
 function *(a::gcmfaces,b::gcmfaces)
   c=similar(a);
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace].*b.f[iFace];
   end
   return c
@@ -461,7 +461,7 @@ end
 
 function *(a::Number,b::gcmfaces)
   c=similar(b);
-  for iFace=1:b.grid["nFaces"]
+  for iFace=1:b.grid.nFaces
     c.f[iFace]=a*b.f[iFace];
   end
   return c
@@ -474,7 +474,7 @@ end
 
 function /(a::gcmfaces,b::gcmfaces)
   c=similar(a);
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace]./b.f[iFace];
   end
   return c
@@ -482,7 +482,7 @@ end
 
 function /(a::Number,b::gcmfaces)
   c=similar(b);
-  for iFace=1:b.grid["nFaces"]
+  for iFace=1:b.grid.nFaces
     c.f[iFace]=a./b.f[iFace];
   end
   return c
@@ -490,7 +490,7 @@ end
 
 function /(a::gcmfaces,b::Number)
   c=similar(a);
-  for iFace=1:a.grid["nFaces"]
+  for iFace=1:a.grid.nFaces
     c.f[iFace]=a.f[iFace]./b;
   end
   return c
@@ -500,7 +500,7 @@ end
 
 function isnan(a::gcmfaces)
     c=similar(a);
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       c.f[iFace]=isnan.(a.f[iFace]);
     end
     return c
@@ -508,7 +508,7 @@ end
 
 function isinf(a::gcmfaces)
     c=similar(a);
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       c.f[iFace]=isinf.(a.f[iFace]);
     end
     return c
@@ -516,7 +516,7 @@ end
 
 function isfinite(a::gcmfaces)
     c=similar(a);
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       c.f[iFace]=isfinite.(a.f[iFace]);
     end
     return c
@@ -524,7 +524,7 @@ end
 
 function sum(a::gcmfaces)
     c=0.0;
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       tmp1=a.f[iFace];
       c=c+sum(tmp1);
     end
@@ -533,7 +533,7 @@ end
 
 function maximum(a::gcmfaces)
     c=-Inf;
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       tmp1=a.f[iFace];
       c=max(c,maximum(tmp1));
     end
@@ -542,7 +542,7 @@ end
 
 function minimum(a::gcmfaces)
     c=Inf;
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       tmp1=a.f[iFace];
       c=min(c,minimum(tmp1));
     end
@@ -551,7 +551,7 @@ end
 
 function fill(val::Any,a::gcmfaces)
     c=similar(a);
-    for iFace=1:a.grid["nFaces"]
+    for iFace=1:a.grid.nFaces
       c.f[iFace]=fill(val,fsize(a,iFace));
     end
     return c

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -5,23 +5,40 @@
 abstract type AbstractGcmfaces{T, N} <: AbstractArray{T, N} end
 
 """
+    gcmgrid
+
+gcmsubset data structure. Available constructors?
+
+"""
+struct gcmgrid
+  path::String
+  class::String
+  nFaces::Int
+  fSize::Array{NTuple{2, Int},1}
+#  ioSize::NTuple{2, Int}
+  ioSize::Array{Int64,2}
+  ioPrec::Type
+  read::Function
+end
+
+"""
     gcmfaces{T, N}
 
 gcmfaces data structure. Available constructors:
 
 ```
-gcmfaces{T,N}(grid::Dict,f::Array{Array{T,N},1},
+gcmfaces{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int})
-gcmfaces(grid::Dict,,::Type{T},
+gcmfaces(grid::gcmgrid,,::Type{T},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int}) where {T,N}
-gcmfaces(grid::Dict,v1::Array{Array{T,N},1}) where {T,N}
+gcmfaces(grid::gcmgrid,v1::Array{Array{T,N},1}) where {T,N}
 gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
-gcmfaces(grid::Dict)
+gcmfaces(grid::gcmgrid)
 gcmfaces()
 ```
 """
 struct gcmfaces{T, N} <: AbstractGcmfaces{T, N}
-   grid::Dict
+   grid::gcmgrid
    f::Array{Array{T,N},1}
    fSize::Array{NTuple{N, Int}}
    aSize::NTuple{N, Int}
@@ -33,15 +50,15 @@ end
 gcmsubset data structure. Available constructors:
 
 ```
-gcmsubset{T,N}(grid::Dict,f::Array{Array{T,N},1},
+gcmsubset{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
                fSize::Array{NTuple{N, Int}},aSize::NTuple{N, Int},
                i::Array{Array{T,N},1},iSize::Array{NTuple{N, Int}})
-gcmsubset(grid::Dict,::Type{T},fSize::Array{NTuple{N, Int}},
+gcmsubset(grid::gcmgrid,::Type{T},fSize::Array{NTuple{N, Int}},
           aSize::NTuple{N,Int},dims::NTuple{N,Int}) where {T,N}
 ```
 """
 struct gcmsubset{T, N} <: AbstractGcmfaces{T, N}
-   grid::Dict
+   grid::gcmgrid
    f::Array{Array{T,N},1}
    fSize::Array{NTuple{N, Int}}
    aSize::NTuple{N, Int}
@@ -51,7 +68,7 @@ end
 
 ## additional constructors for gcmfaces
 
-function gcmfaces(grid::Dict,::Type{T},
+function gcmfaces(grid::gcmgrid,::Type{T},
   fSize::Array{NTuple{N, Int}},
   aSize::NTuple{N,Int}) where {T,N}
   nFaces=grid["nFaces"]
@@ -62,7 +79,7 @@ function gcmfaces(grid::Dict,::Type{T},
   gcmfaces{T,N}(grid,f,fSize,aSize)
 end
 
-function gcmfaces(grid::Dict,
+function gcmfaces(grid::gcmgrid,
   v1::Array{Array{T,N},1}) where {T,N}
   fSize=fsize(v1)
   aSize=fsize(v1,0)
@@ -77,7 +94,7 @@ function gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
   gcmfaces{T,N}(grid,deepcopy(A.f),fSize,aSize)
 end
 
-function gcmfaces(grid::Dict)
+function gcmfaces(grid::gcmgrid)
   T=grid["ioPrec"]
   fSize=grid["fSize"]
   aSize=(prod(grid["ioSize"]),1)
@@ -85,17 +102,18 @@ function gcmfaces(grid::Dict)
 end
 
 function gcmfaces()
-  grid=Dict("nFaces"=>5, "class"=>"llc")
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
-  aSize=(105300, 1);
+  aSize=(105300, 1)
+  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, x -> x)
+
   gcmfaces(grid,T,fSize,aSize)
 end
 
 ## additional constructors for gcmsubset
 
 #maybe: replace this constructor with one that gets A and sets f to view(A.f)
-function gcmsubset(grid::Dict,::Type{T},
+function gcmsubset(grid::gcmgrid,::Type{T},
   fSize::Array{NTuple{N, Int}},aSize::NTuple{N,Int},
   dims::NTuple{N,Int}) where {T,N}
   nFaces=grid["nFaces"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ for nTopo=1:3
     end;
     Npt=nFaces*N*N
     mygrid=GCMGridOnes(grTopo,nFaces,N)
-    @test mygrid["grTopo"] == grTopo
+    @test mygrid["class"] == grTopo
     Rini= 0.; Rend= 0.;
     (Rini,Rend,DXCsm,DYCsm)=demo2(mygrid);
     @test isa(Rend,gcmfaces)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,11 @@ for nTopo=1:3
     elseif nTopo==3; grTopo="ll"; nFaces=1; N=500;
     end;
     Npt=nFaces*N*N
-    mygrid=GCMGridOnes(grTopo,nFaces,N)
-    @test mygrid["class"] == grTopo
+    GridVariables=GCMGridOnes(grTopo,nFaces,N)
+    mygrid=GridVariables["XC"].grid
+    @test mygrid.class == grTopo
     Rini= 0.; Rend= 0.;
-    (Rini,Rend,DXCsm,DYCsm)=demo2(mygrid);
+    (Rini,Rend,DXCsm,DYCsm)=demo2(GridVariables);
     @test isa(Rend,gcmfaces)
     @test sum(isfinite(Rend)) == Npt
     Sini=sqrt(sum(Rini*Rini)/(Npt-1.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,10 @@ for nTopo=1:3
     elseif nTopo==3; grTopo="ll"; nFaces=1; N=500;
     end;
     Npt=nFaces*N*N
-    @test GCMGridOnes(grTopo,nFaces,N) == "GCMGridOnes: passed"
+    mygrid=GCMGridOnes(grTopo,nFaces,N)
+    @test mygrid["grTopo"] == grTopo
     Rini= 0.; Rend= 0.;
-    (Rini,Rend,DXCsm,DYCsm)=demo2();
+    (Rini,Rend,DXCsm,DYCsm)=demo2(mygrid);
     @test isa(Rend,gcmfaces)
     @test sum(isfinite(Rend)) == Npt
     Sini=sqrt(sum(Rini*Rini)/(Npt-1.0))


### PR DESCRIPTION
** All functions of the package are affected by this major, breaking change**

- introduce the `gcmgrid` type to contain grid specifications like `nFaces` & `grTopo`
- add `gcmgrid` instance inside `gcmfaces` type instead of `nFaces` & `grTopo`
- grid specifications are now returned as a `gcmgrid` by `GCMGridSpec`
- grid variables are in turn returned as `Dict` by `GCMGridLoad` that inputs a `gcmgrid`
- remove global grid variables and update doc & tests after `gcmgrid` introduction
- propagate these changes throughout the package functions that now rely
  on `gcmgrid` input arguments rather than global variables and specs.
