### PR TITLE
introduce read / write functions and use in place of read_bin & convert2gcmfaces

### DIFF
--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -17,8 +17,6 @@ export AbstractGcmfaces, gcmfaces, gcmsubset, gcmgrid, fsize, fijind
 export exchange, gradient, convergence, smooth, mask
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
 export findtiles, LatitudeCircles, ThroughFlow
-#The following functions rely on grid specs; currently via global vars.
-export read_bin, convert2array, convert2gcmfaces
 #The following exch_UV differs from normal exchange; incl. exch_UV_N.
 export exch_UV
 #The following codes add dependencies to Plots & NetCDF.

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -60,7 +60,7 @@ end
 
 # read_bin(fil::String,x::gcmfaces)
 function read_bin(fil::String,x::gcmfaces)
-  read_bin(fil,missing,missing,x.mygrid.ioPrec,x.mygrid::gcmgrid)
+  read_bin(fil,missing,missing,eltype(x),x.grid::gcmgrid)
 end
 
 # read_bin(tmp::Array,mygrid::gcmgrid)
@@ -70,5 +70,38 @@ end
 
 # read_bin(tmp::Array,x::gcmfaces)
 function read_bin(tmp::Array,x::gcmfaces)
-  convert2gcmfaces(tmp,x.mygrid)
+  convert2gcmfaces(tmp,x.grid)
+end
+
+## function read
+
+function read(fil::String,x::gcmfaces)
+
+  grTopo=x.grid.class
+  nFaces=x.grid.nFaces
+  facesSize=x.grid.fSize
+  (n1,n2)=x.grid.ioSize
+  n3=Int64(prod(size(x))/n1/n2)
+
+  fid = open(fil)
+  xx = Array{eltype(x),2}(undef,(n1*n2,n3))
+  read!(fid,xx)
+  xx = hton.(xx)
+  close(fid)
+
+  y=similar(x)
+  i0=0; i1=0;
+  for iFace=1:nFaces
+    i0=i1+1;
+    nn=facesSize[iFace][1]; mm=facesSize[iFace][2];
+    i1=i1+nn*mm;
+    if n3>1;
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3));
+    else;
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm));
+    end;
+  end
+
+  return y
+
 end

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -35,6 +35,7 @@ function read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec
   fld = Array{prec,1}(undef,(n1*n2*n3));
   read!(fid,fld);
   fld = hton.(fld);
+  close(fid)
 
   n3>1 ? s=(n1,n2,n3) : s=(n1,n2)
   v0=reshape(fld,s);
@@ -43,14 +44,31 @@ function read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec
 
 end
 
-## read_bin function with reduced list of argument
+## read_bin with reduced list of argument
 
+# read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
 function read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
   read_bin(fil,missing,missing,prec,mygrid::gcmgrid)
 end
 
-## read_bin function with reduced list of argument
-
+# read_bin(fil::String,mygrid::gcmgrid)
 function read_bin(fil::String,mygrid::gcmgrid)
   read_bin(fil,missing,missing,mygrid.ioPrec,mygrid::gcmgrid)
+end
+
+## read_bin with alternative arguments
+
+# read_bin(fil::String,x::gcmfaces)
+function read_bin(fil::String,x::gcmfaces)
+  read_bin(fil,missing,missing,x.mygrid.ioPrec,x.mygrid::gcmgrid)
+end
+
+# read_bin(tmp::Array,mygrid::gcmgrid)
+function read_bin(tmp::Array,mygrid::gcmgrid)
+  convert2gcmfaces(tmp,mygrid)
+end
+
+# read_bin(tmp::Array,x::gcmfaces)
+function read_bin(tmp::Array,x::gcmfaces)
+  convert2gcmfaces(tmp,x.mygrid)
 end

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -75,6 +75,8 @@ end
 
 ## function read
 
+import Base: read, write
+
 function read(fil::String,x::gcmfaces)
 
   grTopo=x.grid.class
@@ -101,6 +103,83 @@ function read(fil::String,x::gcmfaces)
       y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm));
     end;
   end
+
+  return y
+
+end
+
+function read(xx::Array,x::gcmfaces)
+
+  grTopo=x.grid.class
+  nFaces=x.grid.nFaces
+  facesSize=x.grid.fSize
+  (n1,n2)=x.grid.ioSize
+  n3=Int64(prod(size(x))/n1/n2)
+
+  xx=reshape(xx,(n1*n2,n3))
+
+  y=similar(x)
+  i0=0; i1=0;
+  for iFace=1:nFaces
+    i0=i1+1;
+    nn=facesSize[iFace][1]; mm=facesSize[iFace][2];
+    i1=i1+nn*mm;
+    if n3>1;
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3));
+    else;
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm));
+    end;
+  end
+
+  return y
+
+end
+
+
+function write(fil::String,x::gcmfaces)
+
+  grTopo=x.grid.class
+  nFaces=x.grid.nFaces
+  facesSize=x.grid.fSize
+  (n1,n2)=x.grid.ioSize
+  n3=Int64(prod(size(x))/n1/n2)
+
+  y = Array{eltype(x),2}(undef,(n1*n2,n3))
+  i0=0; i1=0;
+  for iFace=1:nFaces;
+    i0=i1+1;
+    nn=facesSize[iFace][1];
+    mm=facesSize[iFace][2];
+    i1=i1+nn*mm;
+    y[i0:i1,:]=reshape(x.f[iFace],(nn*mm,n3));
+  end;
+
+  fid = open(fil,"w")
+  write(fid,ntoh.(y))
+  close(fid)
+
+end
+
+function write(x::gcmfaces)
+
+  grTopo=x.grid.class
+  nFaces=x.grid.nFaces
+  facesSize=x.grid.fSize
+  (n1,n2)=x.grid.ioSize
+  n3=Int64(prod(size(x))/n1/n2)
+
+  y = Array{eltype(x),2}(undef,(n1*n2,n3))
+  i0=0; i1=0;
+  for iFace=1:nFaces;
+    i0=i1+1;
+    nn=facesSize[iFace][1];
+    mm=facesSize[iFace][2];
+    i1=i1+nn*mm;
+    y[i0:i1,:]=reshape(x.f[iFace],(nn*mm,n3));
+  end;
+
+  y=reshape(y,(n1,n2,n3));
+  n3==1 ? y=dropdims(y,dims=3) : nothing
 
   return y
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -33,8 +33,8 @@ function demo1(gridChoice::String)
     D/D
 
     Dexch=exchange(D,4)
-    Darr=convert2array(D)
-    DD=convert2array(Darr,mygrid)
+    Darr=write(D)
+    DD=read(Darr,D)
 
     GridVariables=GCMGridLoad(mygrid)
 
@@ -78,9 +78,8 @@ function demo2(GridVariables::Dict)
     mygrid=GridVariables["XC"].grid
 
     #initialize 2D field of random numbers
-    tmp1=convert2gcmfaces(GridVariables["XC"])
-    tmp1=randn(Float32,size(tmp1))
-    Rini=convert2gcmfaces(tmp1,mygrid)
+    tmp1=randn(Float32,Tuple(mygrid.ioSize))
+    Rini=read(tmp1,gcmfaces(mygrid,Float32))
 
     #apply land mask
     if ndims(GridVariables["hFacC"].f[1])>2

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -17,7 +17,7 @@ function demo1(gridChoice::String)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=mygrid.read(mygrid.path*"Depth.data",mygrid)
+    D=mygrid.read(mygrid.path*"Depth.data",gcmfaces(mygrid))
 
     1000+D
     D+1000
@@ -120,11 +120,11 @@ function demo3()
     mygrid=GCMGridSpec("LLC90")
     GridVariables=GCMGridLoad(mygrid)
 
-    TrspX=mygrid.read(mygrid.path*"TrspX.bin",Float32,mygrid)
-    TrspY=mygrid.read(mygrid.path*"TrspY.bin",Float32,mygrid)
-    TauX=mygrid.read(mygrid.path*"TauX.bin",Float32,mygrid)
-    TauY=mygrid.read(mygrid.path*"TauY.bin",Float32,mygrid)
-    SSH=mygrid.read(mygrid.path*"SSH.bin",Float32,mygrid)
+    TrspX=mygrid.read(mygrid.path*"TrspX.bin",gcmfaces(mygrid,Float32))
+    TrspY=mygrid.read(mygrid.path*"TrspY.bin",gcmfaces(mygrid,Float32))
+    TauX=mygrid.read(mygrid.path*"TauX.bin",gcmfaces(mygrid,Float32))
+    TauY=mygrid.read(mygrid.path*"TauY.bin",gcmfaces(mygrid,Float32))
+    SSH=mygrid.read(mygrid.path*"SSH.bin",gcmfaces(mygrid,Float32))
 
     (UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables)
 

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -33,8 +33,8 @@ function demo1(gridChoice::String)
     D/D
 
     Dexch=exchange(D,4)
-    Darr=write(D)
-    DD=read(Darr,D)
+    Darr=mygrid.write(D)
+    DD=mygrid.read(Darr,D)
 
     GridVariables=GCMGridLoad(mygrid)
 
@@ -79,7 +79,7 @@ function demo2(GridVariables::Dict)
 
     #initialize 2D field of random numbers
     tmp1=randn(Float32,Tuple(mygrid.ioSize))
-    Rini=read(tmp1,gcmfaces(mygrid,Float32))
+    Rini=mygrid.read(tmp1,gcmfaces(mygrid,Float32))
 
     #apply land mask
     if ndims(GridVariables["hFacC"].f[1])>2

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -17,7 +17,7 @@ function demo1(gridChoice::String)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=read_bin(mygrid.path*"Depth.data",mygrid.ioPrec,mygrid)
+    D=mygrid.read(mygrid.path*"Depth.data",mygrid)
 
     1000+D
     D+1000
@@ -60,8 +60,8 @@ Demonstrate higher level functions using `smooth`. Call sequence:
 (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2();
 
 include(joinpath(dirname(pathof(MeshArrays)),"gcmfaces_plot.jl"))
-qwckplot(Rini)
-qwckplot(Rend)
+qwckplot(Rini,"raw noise")
+qwckplot(Rend,"smoothed noise")
 ```
 
 """
@@ -120,11 +120,11 @@ function demo3()
     mygrid=GCMGridSpec("LLC90")
     GridVariables=GCMGridLoad(mygrid)
 
-    TrspX=read_bin(mygrid.path*"TrspX.bin",Float32,mygrid)
-    TrspY=read_bin(mygrid.path*"TrspY.bin",Float32,mygrid)
-    TauX=read_bin(mygrid.path*"TauX.bin",Float32,mygrid)
-    TauY=read_bin(mygrid.path*"TauY.bin",Float32,mygrid)
-    SSH=read_bin(mygrid.path*"SSH.bin",Float32,mygrid)
+    TrspX=mygrid.read(mygrid.path*"TrspX.bin",Float32,mygrid)
+    TrspY=mygrid.read(mygrid.path*"TrspY.bin",Float32,mygrid)
+    TauX=mygrid.read(mygrid.path*"TauX.bin",Float32,mygrid)
+    TauY=mygrid.read(mygrid.path*"TauY.bin",Float32,mygrid)
+    SSH=mygrid.read(mygrid.path*"SSH.bin",Float32,mygrid)
 
     (UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables)
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -39,7 +39,7 @@ else;
     error("unknown gridName case");
 end;
 
-mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> missing)
+mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read_bin)
 
 return mygrid
 
@@ -64,7 +64,7 @@ function GCMGridLoad(mygrid::gcmgrid)
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth")
     for ii=1:length(list0)
-        tmp1=read_bin(mygrid.path*list0[ii]*".data",mygrid.ioPrec,mygrid)
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",mygrid)
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -123,7 +123,7 @@ function GCMGridOnes(grTp,nF,nP)
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=read(tmp1,gcmfaces(mygrid));
+        tmp1=mygrid.read(tmp1,gcmfaces(mygrid));
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -39,7 +39,7 @@ else;
     error("unknown gridName case");
 end;
 
-mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read)
+mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
 
 return mygrid
 
@@ -117,7 +117,7 @@ function GCMGridOnes(grTp,nF,nP)
     facesSize[:].=[(nP,nP)]
     ioPrec=Float32
 
-    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, x -> missing)
+    mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read, write)
 
     GridVariables=Dict()
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -39,7 +39,7 @@ else;
     error("unknown gridName case");
 end;
 
-mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read_bin)
+mygrid=gcmgrid(grDir,grTopo,nFaces,facesSize, ioSize, ioPrec, read)
 
 return mygrid
 
@@ -61,10 +61,11 @@ Based on the MITgcm naming convention, grid variables are:
 function GCMGridLoad(mygrid::gcmgrid)
 
     GridVariables=Dict()
+
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
-    "DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth")
+    "DXC","DXG","DYC","DYG","Depth")
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",mygrid)
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",gcmfaces(mygrid))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
@@ -83,6 +84,15 @@ function GCMGridLoad(mygrid::gcmgrid)
         read!(fid,tmp1)
         tmp1 = hton.(tmp1)
 
+        tmp2=Symbol(list0[ii])
+        @eval (($tmp2) = ($tmp1))
+        GridVariables[list0[ii]]=tmp1
+    end
+
+    list0=("hFacC","hFacS","hFacW")
+    n3=length(GridVariables["RC"])
+    for ii=1:length(list0)
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",gcmfaces(mygrid,mygrid.ioPrec,n3))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -123,7 +123,7 @@ function GCMGridOnes(grTp,nF,nP)
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=convert2gcmfaces(tmp1,mygrid);
+        tmp1=read(tmp1,gcmfaces(mygrid));
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1

--- a/src/gcmfaces_plot.jl
+++ b/src/gcmfaces_plot.jl
@@ -28,7 +28,7 @@ end
 Plot input using convert2array and heatmap + add title
 """
 function qwckplot(fld::gcmfaces,ttl::String)
-    arr=convert2array(fld)
+    arr=MeshArrays.convert2array(fld)
     arr=permutedims(arr,[2 1])
     #This uses Plots.jl:
     p=heatmap(arr,title=ttl)

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -85,6 +85,23 @@ function gcmfaces(grid::gcmgrid,::Type{T},
   gcmfaces{T,N}(grid,f,fSize,aSize)
 end
 
+function gcmfaces(grid::gcmgrid,::Type{T}) where {T,N}
+  nFaces=grid.nFaces
+  fSize=grid.fSize
+  aSize=(prod(grid.ioSize),1)
+  gcmfaces(grid,T,fSize,aSize)
+end
+
+function gcmfaces(grid::gcmgrid,::Type{T},n3::Int) where {T,N}
+  nFaces=grid.nFaces
+  fSize=Array{NTuple{3, Int},1}(undef,nFaces)
+  for a=1:nFaces
+    fSize[a]=(grid.fSize[a][1],grid.fSize[a][2],n3)
+  end
+  aSize=(prod(grid.ioSize),1,n3)
+  gcmfaces(grid,T,fSize,aSize)
+end
+
 #gcmfaces{T,N}(grid::gcmgrid)
 #gcmfaces(grid::gcmgrid,::Type{T}) where {T}
 #gcmfaces(grid::gcmgrid,::Type{T},n3::Int) where {T}
@@ -115,7 +132,7 @@ function gcmfaces()
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
   aSize=(105300, 1)
-  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, read_bin)
+  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, read)
 
   gcmfaces(grid,T,fSize,aSize)
 end

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -111,7 +111,7 @@ function gcmfaces()
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
   aSize=(105300, 1)
-  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, x -> missing)
+  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, read_bin)
 
   gcmfaces(grid,T,fSize,aSize)
 end

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -12,7 +12,7 @@ gcmgrid data structure. Available constructors:
 ```
 gcmgrid(path::String, class::String, nFaces::Int,
         fSize::Array{NTuple{2, Int},1}, ioSize::Array{Int64,2},
-        ioPrec::Type, read::Function)
+        ioPrec::Type, read::Function, write::Function)
 ```
 """
 struct gcmgrid
@@ -24,6 +24,7 @@ struct gcmgrid
   ioSize::Array{Int64,2}
   ioPrec::Type
   read::Function
+  write::Function
 end
 
 """
@@ -132,7 +133,7 @@ function gcmfaces()
   T=Float64
   fSize=[(90, 270), (90, 270), (90, 90), (270, 90), (270, 90)]
   aSize=(105300, 1)
-  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, read)
+  grid=gcmgrid("", "llc", 5, fSize, [90 1170], T, read, write)
 
   gcmfaces(grid,T,fSize,aSize)
 end

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -37,7 +37,7 @@ gcmfaces{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
 gcmfaces(grid::gcmgrid,v1::Array{Array{T,N},1}) where {T,N}
 gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
 
-gcmfaces(grid::gcmgrid,,::Type{T},
+gcmfaces(grid::gcmgrid,::Type{T},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int}) where {T,N}
 gcmfaces(grid::gcmgrid)
 gcmfaces()
@@ -84,6 +84,10 @@ function gcmfaces(grid::gcmgrid,::Type{T},
   end
   gcmfaces{T,N}(grid,f,fSize,aSize)
 end
+
+#gcmfaces{T,N}(grid::gcmgrid)
+#gcmfaces(grid::gcmgrid,::Type{T}) where {T}
+#gcmfaces(grid::gcmgrid,::Type{T},n3::Int) where {T}
 
 function gcmfaces(grid::gcmgrid,
   v1::Array{Array{T,N},1}) where {T,N}


### PR DESCRIPTION
- keep read_bin, convert2array, convert2gcmfaces but don't export them
- new read_bin methods were also added along the way
- read / write are used via mygrid.read / mygrid.write
- in demo1, drop convert2array example; replace with in memory write & read example
- qwckplot now calls MeshArrays.convert2array (might revisit later)
- add gcmfaces constructor methods