### PR TITLE
Revisit custom types & add potential replacement for `gcmfaces` (`gcmarray`)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,8 +29,8 @@ At the command line, one can reproduce the same computation as follows:
 
 ```
 using MeshArrays
-isdir("GRID_LLC90") ? GridVariables=GCMGridLoad(GCMGridSpec("LLC90")) : GridVariables=GCMGridOnes("cs",6,100);
-                    
+isdir("GRID_LLC90") ? GridVariables=GCMGridLoad(GCMGridSpec("LLC90")) : 
+					  GridVariables=GCMGridOnes("cs",6,100);
 (Rini,Rend,DXCsm,DYCsm)= MeshArrays.demo2(GridVariables);
 ```
 
@@ -38,11 +38,11 @@ For plotting directions, see the help section (`?MeshArrays.demo2`). Additional 
 
 ## Main Features
 
-**MeshArrays.jl** composite types contain array collections where arrays are typically inter-connected at their edges. It provides `exchange functions` that transfer data between neighbor arrays so that the user can extend the domain of computation as needed e.g. for interpolation or to compute spatial derivatives.
+**MeshArrays.jl** composite types contain array collections where arrays are typically inter-connected at their edges. It provides `exchange()` functions that transfer data between neighbor arrays so that the user can extend the domain of computation as needed e.g. for interpolation or to compute spatial derivatives.
 
-The composite types specify how each array collection forms a mesh and provide information to allow `exchange` to dispatch to the appropriate method. Various configurations that are commonly used in `Earth System Models` are implemented using the concrete type called `gcmfaces`. This type contains a `gcmgrid` instance that provides grid specifications (incl. location on disk). Embedded arrays, or meshes, each represent a subdomain within, e.g., an Earth System Model grid.
+The composite types specify how each array collection forms a mesh and provide information to allow `exchange` to dispatch to the appropriate method. Various configurations that are commonly used in `Earth System Models` are implemented using the concrete type called `MeshArray`. In fact `MeshArray` is an alias for other types that can thus used interchangeably (initially: `gcmfaces` or `gcmarray`). These types contain a `gcmgrid` instance that provides grid specifications (incl. location on disk). Embedded arrays, or meshes, each represent a subdomain within, e.g., an Earth System Model grid. For example, `gcmarray` represents a variable `x` as an array of 2D ragged arrays `x.f`.
 
-_About names:_ the `gcmfaces` name derives from a [previous Matlab / Octave package](https://gcmfaces.readthedocs.io/en/latest/), introduced in [Forget et al., 2015](http://www.geosci-model-dev.net/8/3071/2015/) (`doi:10.5194/gmd-8-3071-2015`), which provided the inspiratoin for `MeshArrays.jl`. To break it down, `GCM` is an acronym for General Circulation Model, or Global Climate Model (see [this wikipedia entry](https://en.wikipedia.org/wiki/General_circulation_model)), and `faces` can mean meshes, arrays, facets, or subdomains.
+This package derives from a [previous Matlab / Octave package](https://gcmfaces.readthedocs.io/en/latest/), `gcmfaces` introduced in [Forget et al., 2015](http://www.geosci-model-dev.net/8/3071/2015/) (`doi:10.5194/gmd-8-3071-2015`). `GCM` is an acronym for General Circulation Model, or Global Climate Model (see [this wikipedia entry](https://en.wikipedia.org/wiki/General_circulation_model)), and `faces` can mean meshes, arrays, facets, or subdomains (`x.f` in a `MeshArray ` instance `x`).
 
 ## API index
 

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -4,9 +4,7 @@ module MeshArrays
 
 #using Printf
 
-include("gcmfaces_type.jl");
-MeshArray=gcmfaces
-
+include("Types.jl");
 include("gcmfaces_grids.jl");
 include("gcmfaces_calc.jl");
 include("gcmfaces_exch.jl");

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -2,9 +2,11 @@
 
 module MeshArrays
 
-using Printf
+#using Printf
 
 include("gcmfaces_type.jl");
+MeshArray=gcmfaces
+
 include("gcmfaces_grids.jl");
 include("gcmfaces_calc.jl");
 include("gcmfaces_exch.jl");
@@ -12,8 +14,7 @@ include("gcmfaces_convert.jl");
 include("gcmfaces_IO.jl");
 include("gcmfaces_demo.jl");
 
-
-export AbstractGcmfaces, gcmfaces, gcmsubset, gcmgrid, fsize, fijind
+export AbstractMeshArray, MeshArray, gcmsubset, gcmgrid, fsize, fijind
 export exchange, gradient, convergence, smooth, mask
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
 export findtiles, LatitudeCircles, ThroughFlow
@@ -22,6 +23,5 @@ export exch_UV
 #The following codes add dependencies to Plots & NetCDF.
 #include("gcmfaces_plot.jl");
 #include("gcmfaces_nctiles.jl");
-
 
 end # module

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -12,7 +12,7 @@ include("gcmfaces_convert.jl");
 include("gcmfaces_IO.jl");
 include("gcmfaces_demo.jl");
 
-export AbstractMeshArray, MeshArray, gcmsubset, gcmgrid, fsize, fijind
+export AbstractMeshArray, MeshArray, gcmsubset, gcmgrid, nFacesEtc, fijind
 export exchange, gradient, convergence, smooth, mask
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
 export findtiles, LatitudeCircles, ThroughFlow

--- a/src/MeshArrays.jl
+++ b/src/MeshArrays.jl
@@ -12,10 +12,10 @@ include("gcmfaces_convert.jl");
 include("gcmfaces_IO.jl");
 include("gcmfaces_demo.jl");
 
-export AbstractMeshArray, MeshArray, gcmsubset, gcmgrid, nFacesEtc, fijind
+export AbstractMeshArray, MeshArray, gcmgrid
 export exchange, gradient, convergence, smooth, mask
 export GCMGridSpec, GCMGridLoad, GCMGridOnes
-export findtiles, LatitudeCircles, ThroughFlow
+export nFacesEtc, fijind, findtiles, LatitudeCircles, ThroughFlow
 #The following exch_UV differs from normal exchange; incl. exch_UV_N.
 export exch_UV
 #The following codes add dependencies to Plots & NetCDF.

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -31,8 +31,7 @@ end
 
 ## concrete type and MeshArray alias:
 
-#struct gcmarray{T, N} <: AbstractMeshArray{T, N} end
-#struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end
-
-include("gcmfaces_type.jl"); MeshArray=gcmfaces
-#include("gcmarray_type.jl"); MeshArray=gcmarray
+include("gcmfaces_type.jl");
+include("gcmarray_type.jl");
+MeshArray=gcmfaces
+#MeshArray=gcmarray

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1,0 +1,37 @@
+
+"""
+    AbstractMeshArray{T, N}
+
+Subtype of AbstractArray{T, N}
+"""
+abstract type AbstractMeshArray{T, N} <: AbstractArray{T, N} end
+
+"""
+    gcmgrid
+
+gcmgrid data structure. Available constructors:
+
+```
+gcmgrid(path::String, class::String, nFaces::Int,
+        fSize::Array{NTuple{2, Int},1}, ioSize::Array{Int64,2},
+        ioPrec::Type, read::Function, write::Function)
+```
+"""
+struct gcmgrid
+  path::String
+  class::String
+  nFaces::Int
+  fSize::Array{NTuple{2, Int},1}
+#  ioSize::NTuple{2, Int}
+  ioSize::Array{Int64,2}
+  ioPrec::Type
+  read::Function
+  write::Function
+end
+
+## concrete type and MeshArray alias:
+
+#include("gcmfaces_type.jl"); MeshArray=gcmfaces
+#include("gcmarray_type.jl"); MeshArray=gcmarray
+#include("gcmarray_type01.jl"); MeshArray=gcmarray
+include("gcmarray_type02.jl"); MeshArray=gcmarray

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -32,6 +32,6 @@ end
 ## concrete type and MeshArray alias:
 
 #include("gcmfaces_type.jl"); MeshArray=gcmfaces
-#include("gcmarray_type.jl"); MeshArray=gcmarray
-#include("gcmarray_type01.jl"); MeshArray=gcmarray
-include("gcmarray_type02.jl"); MeshArray=gcmarray
+
+struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end
+include("gcmarray_type.jl"); MeshArray=gcmarray

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -34,5 +34,5 @@ end
 #struct gcmarray{T, N} <: AbstractMeshArray{T, N} end
 #struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end
 
-#include("gcmfaces_type.jl"); MeshArray=gcmfaces
-include("gcmarray_type.jl"); MeshArray=gcmarray
+include("gcmfaces_type.jl"); MeshArray=gcmfaces
+#include("gcmarray_type.jl"); MeshArray=gcmarray

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -32,7 +32,7 @@ end
 ## concrete type and MeshArray alias:
 
 #struct gcmarray{T, N} <: AbstractMeshArray{T, N} end
-#include("gcmfaces_type.jl"); MeshArray=gcmfaces
+#struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end
 
-struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end
+#include("gcmfaces_type.jl"); MeshArray=gcmfaces
 include("gcmarray_type.jl"); MeshArray=gcmarray

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -31,6 +31,7 @@ end
 
 ## concrete type and MeshArray alias:
 
+#struct gcmarray{T, N} <: AbstractMeshArray{T, N} end
 #include("gcmfaces_type.jl"); MeshArray=gcmfaces
 
 struct gcmfaces{T, N} <: AbstractMeshArray{T, N} end

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -181,3 +181,142 @@ function my_getindex_evalf(bc,I)
   args = Broadcast._getindex(bc.args, I)
   return bc.f.(args...)
 end
+
+###
+
+import Base: +, -, *, /
+import Base: isnan, isinf, isfinite
+import Base: maximum, minimum, sum, fill
+
+#+(a::gcmarray,b::gcmarray) = a.+b
+function +(a::gcmarray,b::gcmarray)
+  c=similar(a)
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c.f[iFace]=a.f[iFace]+b.f[iFace]
+    else
+      for i3=1:n3
+        c.f[iFace,i3]=a.f[iFace,i3]+b.f[iFace,i3]
+      end
+    end
+  end
+  return c
+end
+
+function -(a::gcmarray,b::gcmarray)
+  c=similar(a)
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c.f[iFace]=a.f[iFace]-b.f[iFace]
+    else
+      for i3=1:n3
+        c.f[iFace,i3]=a.f[iFace,i3]-b.f[iFace,i3]
+      end
+    end
+  end
+  return c
+end
+
+function /(a::gcmarray,b::gcmarray)
+  c=similar(a)
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c.f[iFace]=a.f[iFace]./b.f[iFace]
+    else
+      for i3=1:n3
+        c.f[iFace,i3]=a.f[iFace,i3]./b.f[iFace,i3]
+      end
+    end
+  end
+  return c
+end
+
+function *(a::gcmarray,b::gcmarray)
+  c=similar(a)
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c.f[iFace]=a.f[iFace].*b.f[iFace]
+    else
+      for i3=1:n3
+        c.f[iFace,i3]=a.f[iFace,i3].*b.f[iFace,i3]
+      end
+    end
+  end
+  return c
+end
+
+isnan(a::gcmarray) = isnan.(a)
+isinf(a::gcmarray) = isinf.(a)
+isfinite(a::gcmarray) = isfinite.(a)
+
+function maximum(a::gcmarray)
+  c=-Inf;
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c=max(c,maximum(a.f[iFace]))
+    else
+      for i3=1:n3
+        c=max(c,maximum(a.f[iFace,i3]))
+      end
+    end
+  end
+  return c
+end
+
+function minimum(a::gcmarray)
+  c=-Inf;
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c=max(c,minimum(a.f[iFace]))
+    else
+      for i3=1:n3
+        c=max(c,minimum(a.f[iFace,i3]))
+      end
+    end
+  end
+  return c
+end
+
+function sum(a::gcmarray)
+  c=0.0
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c=c+sum(a.f[iFace])
+    else
+      for i3=1:n3
+        c=c+sum(a.f[iFace,i3])
+      end
+    end
+  end
+  return c
+end
+
+function fill(val::Any,a::gcmarray)
+  c=similar(a)
+  nFaces=length(a.fIndex)
+  n3=size(a.f,2)
+  for iFace=1:nFaces
+    if ndims(a)==1
+      c.f[iFace]=fill(val,a.fSize[iFace])
+    else
+      for i3=1:n3
+        c.f[iFace,i3]=fill(val,a.fSize[iFace])
+      end
+    end
+  end
+  return c
+end

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -1,0 +1,183 @@
+
+# ### gcmarray{T, N} and constructors
+#
+# gcmarray data structure. Available constructors:
+#
+# ```
+# gcmarray{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
+#          fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
+# gcmarray(grid::gcmgrid,
+#          fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
+#
+# gcmarray(grid::gcmgrid,::Type{T})
+# gcmarray(grid::gcmgrid,::Type{T},n3::Int)
+# ```
+
+# +
+struct gcmarray{T, N} <: AbstractMeshArray{T, N}
+   grid::gcmgrid
+   f::Array{Array{T,2},N}
+   fSize::Array{NTuple{2, Int}}
+   fIndex::Array{Int,1}
+end
+
+function gcmarray(grid::gcmgrid,::Type{T},
+        fSize::Array{NTuple{2, Int}},
+        fIndex::Array{Int,1}) where {T}
+  nFaces=length(fIndex)
+  f=Array{Array{T,2},1}(undef,nFaces)
+  for a=1:nFaces
+    f[a]=Array{T}(undef,fSize[a])
+  end
+  gcmarray{T,1}(grid,f,fSize,fIndex)
+end
+
+function gcmarray(grid::gcmgrid,::Type{T},
+        fSize::Array{NTuple{2, Int}},
+        fIndex::Array{Int,1},n3::Int) where {T}
+  nFaces=length(fIndex)
+  f=Array{Array{T,2},2}(undef,nFaces,n3)
+  for a=1:nFaces; for i3=1:n3;
+    f[a,i3]=Array{T}(undef,fSize[a]...)
+  end; end;
+  gcmarray{T,2}(grid,f,fSize,fIndex)
+end
+
+# +
+function gcmarray(grid::gcmgrid,::Type{T}) where {T}
+  nFaces=grid.nFaces
+  fSize=grid.fSize
+  fIndex=collect(1:grid.nFaces)
+  gcmarray(grid,T,fSize,fIndex)
+end
+
+## this one needs to be redone: fSize 2D, f 3D
+function gcmarray(grid::gcmgrid,::Type{T},n3::Int) where {T}
+  nFaces=grid.nFaces
+  fSize=grid.fSize
+  fIndex=collect(1:grid.nFaces)
+  gcmarray(grid,T,fSize,fIndex,n3)
+end
+
+# -
+
+# # Interface Methods
+
+# +
+Base.size(A::gcmarray) = size(A.f)
+Base.size(A::gcmarray, dim::Integer) = size(A)[dim]
+
+# +
+function Base.getindex(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+    return A.f[I...]
+end
+
+"""
+    getindexetc(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+
+Same as getindex but also returns the face size and index
+"""
+function getindexetc(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+    f=A.f[I...]
+    fSize=A.fSize[I[1]]
+    fIndex=A.fIndex[I[1]]
+    return f,fSize,fIndex
+end
+# -
+
+function Base.setindex!(A::gcmarray{T, N}, v, I::Vararg{Int, N}) where {T,N}
+  return (A.f[I...] = v)
+end
+
+function Base.view(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+  return view(A.f,I...)
+end
+
+# ### Custom pretty-printing, similar, and broadcast
+
+function Base.show(io::IO, z::gcmarray{T, N}) where {T,N}
+    printstyled(io, " gcmarray \n",color=:normal)
+    fs=z.fSize
+    printstyled(io, "  grid type   = ",color=:normal)
+    printstyled(io, "$(z.grid.class)\n",color=:blue)
+    printstyled(io, "  array size  = ",color=:normal)
+    printstyled(io, "$(size(z))\n",color=:blue)
+
+    if ~isassigned(z.f);
+      printstyled(io, "  data type   = ",color=:normal)
+      printstyled(io, "unassigned\n",color=:green)
+      printstyled(io, "  tile sizes  = ",color=:normal)
+      printstyled(io, "unassigned\n",color=:green)
+    else
+      printstyled(io, "  data type   = ",color=:normal)
+      printstyled(io, "$(typeof(z.f[1][1]))\n",color=:blue)
+      printstyled(io, "  face sizes  = ",color=:normal)
+      printstyled(io, "$(fs[1])\n",color=:blue)
+      for iFace=2:length(fs)
+        printstyled(io, "                ",color=:normal)
+        printstyled(io, "$(fs[iFace])\n",color=:blue)
+      end
+    end
+
+  return
+end
+
+function Base.similar(A::gcmarray)
+    if ndims(A)==1
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex)
+    else
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2))
+    end
+    return B
+end
+
+# ### Customize broadcasting
+
+Base.BroadcastStyle(::Type{<:gcmarray}) = Broadcast.ArrayStyle{gcmarray}()
+
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{gcmarray}}, ::Type{ElType}) where ElType
+  # Scan the inputs for the gcmarray:
+  A = find_gcmarray(bc)
+  # Create the gcmarray output:
+  #similar(A)
+  if ndims(A)==1
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex)
+  else
+        B=gcmarray(A.grid,eltype(A),A.fSize,A.fIndex,size(A,2))
+  end
+  return B
+end
+
+find_gcmarray(bc::Base.Broadcast.Broadcasted) = find_gcmarray(bc.args)
+find_gcmarray(args::Tuple) = find_gcmarray(find_gcmarray(args[1]), Base.tail(args))
+find_gcmarray(x) = x
+find_gcmarray(a::gcmarray, rest) = a
+find_gcmarray(::Any, rest) = find_gcmarray(rest)
+
+####
+
+import Base: copyto!
+
+# Specialize this method if all you want to do is specialize on typeof(dest)
+@inline function copyto!(dest::MeshArrays.gcmarray, bc::Broadcast.Broadcasted{Nothing})
+    axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
+    # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
+    if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
+        A = bc.args[1]
+        if axes(dest) == axes(A)
+            return copyto!(dest, A)
+        end
+    end
+    bc′ = Broadcast.preprocess(dest, bc)
+    @simd for I in eachindex(bc′)
+        #@inbounds dest[I] = bc′[I]
+        @inbounds dest[I] = my_getindex_evalf(bc′,I)
+    end
+    return dest
+end
+
+function my_getindex_evalf(bc,I)
+  @boundscheck checkbounds(bc, I)
+  args = Broadcast._getindex(bc.args, I)
+  return bc.f.(args...)
+end

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -75,6 +75,8 @@ end
     getindexetc(A::gcmarray, I::Vararg{_}) where {T,N}
 
 Same as getindex but also returns the face size and index
+
+(needed in other types?)
 """
 function getindexetc(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
     f=A.f[I...]
@@ -268,3 +270,10 @@ function nFacesEtc(a::gcmarray)
   ndims(a.f)>1 ? n3=size(a.f,2) : n3=1
   return nFaces, n3
 end
+
+"""
+    fijind(A::gcmarray,ij::Int)
+
+Compute face and local indices (f,j,k?) from global index (ij?).
+"""
+#missing functionality

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -1,19 +1,19 @@
 
-# ### gcmarray{T, N} and constructors
-#
-# gcmarray data structure. Available constructors:
-#
-# ```
-# gcmarray{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
-#          fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
-# gcmarray(grid::gcmgrid,
-#          fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
-#
-# gcmarray(grid::gcmgrid,::Type{T})
-# gcmarray(grid::gcmgrid,::Type{T},n3::Int)
-# ```
+"""
+    gcmarray{T, N}
 
-# +
+gcmarray data structure. Available constructors:
+
+```
+gcmarray{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
+         fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
+gcmarray(grid::gcmgrid,
+         fSize::Array{NTuple{N, Int}},fIndex::Array{Int,1})
+
+gcmarray(grid::gcmgrid,::Type{T})
+gcmarray(grid::gcmgrid,::Type{T},n3::Int)
+```
+"""
 struct gcmarray{T, N} <: AbstractMeshArray{T, N}
    grid::gcmgrid
    f::Array{Array{T,2},N}
@@ -51,7 +51,6 @@ function gcmarray(grid::gcmgrid,::Type{T}) where {T}
   gcmarray(grid,T,fSize,fIndex)
 end
 
-## this one needs to be redone: fSize 2D, f 3D
 function gcmarray(grid::gcmgrid,::Type{T},n3::Int) where {T}
   nFaces=grid.nFaces
   fSize=grid.fSize
@@ -73,7 +72,7 @@ function Base.getindex(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,
 end
 
 """
-    getindexetc(A::gcmarray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+    getindexetc(A::gcmarray, I::Vararg{_}) where {T,N}
 
 Same as getindex but also returns the face size and index
 """
@@ -259,6 +258,11 @@ end
 
 ###
 
+"""
+    nFacesEtc(a::gcmarray)
+
+Return nFaces, n3 (1 in 2D case; >1 otherwise)
+"""
 function nFacesEtc(a::gcmarray)
   nFaces=length(a.fIndex)
   ndims(a.f)>1 ? n3=size(a.f,2) : n3=1

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -191,64 +191,32 @@ import Base: maximum, minimum, sum, fill
 #+(a::gcmarray,b::gcmarray) = a.+b
 function +(a::gcmarray,b::gcmarray)
   c=similar(a)
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c.f[iFace]=a.f[iFace]+b.f[iFace]
-    else
-      for i3=1:n3
-        c.f[iFace,i3]=a.f[iFace,i3]+b.f[iFace,i3]
-      end
-    end
+  for I in eachindex(a)
+    c[I] = a[I] + b[I]
   end
   return c
 end
 
 function -(a::gcmarray,b::gcmarray)
   c=similar(a)
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c.f[iFace]=a.f[iFace]-b.f[iFace]
-    else
-      for i3=1:n3
-        c.f[iFace,i3]=a.f[iFace,i3]-b.f[iFace,i3]
-      end
-    end
+  for I in eachindex(a)
+    c[I] = a[I] - b[I]
   end
   return c
 end
 
 function /(a::gcmarray,b::gcmarray)
   c=similar(a)
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c.f[iFace]=a.f[iFace]./b.f[iFace]
-    else
-      for i3=1:n3
-        c.f[iFace,i3]=a.f[iFace,i3]./b.f[iFace,i3]
-      end
-    end
+  for I in eachindex(a)
+    c[I] = a[I] ./ b[I]
   end
   return c
 end
 
 function *(a::gcmarray,b::gcmarray)
   c=similar(a)
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c.f[iFace]=a.f[iFace].*b.f[iFace]
-    else
-      for i3=1:n3
-        c.f[iFace,i3]=a.f[iFace,i3].*b.f[iFace,i3]
-      end
-    end
+  for I in eachindex(a)
+    c[I] = a[I] .* b[I]
   end
   return c
 end
@@ -259,64 +227,32 @@ isfinite(a::gcmarray) = isfinite.(a)
 
 function maximum(a::gcmarray)
   c=-Inf;
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c=max(c,maximum(a.f[iFace]))
-    else
-      for i3=1:n3
-        c=max(c,maximum(a.f[iFace,i3]))
-      end
-    end
+  for I in eachindex(a)
+    c = max(c,maximum(a[I]))
   end
   return c
 end
 
 function minimum(a::gcmarray)
   c=-Inf;
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c=max(c,minimum(a.f[iFace]))
-    else
-      for i3=1:n3
-        c=max(c,minimum(a.f[iFace,i3]))
-      end
-    end
+  for I in eachindex(a)
+    c = min(c,minimum(a[I]))
   end
   return c
 end
 
 function sum(a::gcmarray)
   c=0.0
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c=c+sum(a.f[iFace])
-    else
-      for i3=1:n3
-        c=c+sum(a.f[iFace,i3])
-      end
-    end
+  for I in eachindex(a)
+    c = c + sum(a[I])
   end
   return c
 end
 
 function fill(val::Any,a::gcmarray)
   c=similar(a)
-  nFaces=length(a.fIndex)
-  n3=size(a.f,2)
-  for iFace=1:nFaces
-    if ndims(a)==1
-      c.f[iFace]=fill(val,a.fSize[iFace])
-    else
-      for i3=1:n3
-        c.f[iFace,i3]=fill(val,a.fSize[iFace])
-      end
-    end
+  for I in eachindex(a)
+    c[I] = fill(val,size(a[I]))
   end
   return c
 end

--- a/src/gcmarray_type.jl
+++ b/src/gcmarray_type.jl
@@ -256,3 +256,11 @@ function fill(val::Any,a::gcmarray)
   end
   return c
 end
+
+###
+
+function nFacesEtc(a::gcmarray)
+  nFaces=length(a.fIndex)
+  ndims(a.f)>1 ? n3=size(a.f,2) : n3=1
+  return nFaces, n3
+end

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -77,7 +77,7 @@ end
 
 import Base: read, write
 
-function read(fil::String,x::AbstractMeshArray)
+function read(fil::String,x::MeshArray)
 
   grTopo=x.grid.class
   facesSize=x.grid.fSize

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -77,6 +77,15 @@ end
 
 import Base: read, write
 
+"""
+    read(fil::String,x::MeshArray)
+
+Read binary file to MeshArray. Other methods:
+
+```
+read(xx::Array,x::MeshArray) #from Array
+```
+"""
 function read(fil::String,x::MeshArray)
 
   grTopo=x.grid.class
@@ -143,6 +152,15 @@ function read(xx::Array,x::MeshArray)
 end
 
 
+"""
+    write(fil::String,x::MeshArray)
+
+Write MeshArray to binary file. Other methods:
+
+```
+write(xx::Array,x::MeshArray) #to Array
+```
+"""
 function write(fil::String,x::MeshArray)
 
   grTopo=x.grid.class

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -4,7 +4,7 @@
 """
     read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec::DataType,mygrid::gcmgrid)
 
-Read model output from binary file and convert to gcmfaces structure. Other methods:
+Read model output from binary file and convert to MeshArray. Other methods:
 
 ```
 read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
@@ -58,8 +58,8 @@ end
 
 ## read_bin with alternative arguments
 
-# read_bin(fil::String,x::gcmfaces)
-function read_bin(fil::String,x::gcmfaces)
+# read_bin(fil::String,x::MeshArray)
+function read_bin(fil::String,x::MeshArray)
   read_bin(fil,missing,missing,eltype(x),x.grid::gcmgrid)
 end
 
@@ -68,8 +68,8 @@ function read_bin(tmp::Array,mygrid::gcmgrid)
   convert2gcmfaces(tmp,mygrid)
 end
 
-# read_bin(tmp::Array,x::gcmfaces)
-function read_bin(tmp::Array,x::gcmfaces)
+# read_bin(tmp::Array,x::MeshArray)
+function read_bin(tmp::Array,x::MeshArray)
   convert2gcmfaces(tmp,x.grid)
 end
 
@@ -77,13 +77,15 @@ end
 
 import Base: read, write
 
-function read(fil::String,x::gcmfaces)
+function read(fil::String,x::AbstractMeshArray)
 
   grTopo=x.grid.class
   nFaces=x.grid.nFaces
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
-  n3=Int64(prod(size(x))/n1/n2)
+  n3=1
+# isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
+  isa(x,gcmfaces) ? n3=Int64(prod(size(x))/n1/n2) : nothing
 
   fid = open(fil)
   xx = Array{eltype(x),2}(undef,(n1*n2,n3))
@@ -108,7 +110,7 @@ function read(fil::String,x::gcmfaces)
 
 end
 
-function read(xx::Array,x::gcmfaces)
+function read(xx::Array,x::MeshArray)
 
   grTopo=x.grid.class
   nFaces=x.grid.nFaces
@@ -136,7 +138,7 @@ function read(xx::Array,x::gcmfaces)
 end
 
 
-function write(fil::String,x::gcmfaces)
+function write(fil::String,x::MeshArray)
 
   grTopo=x.grid.class
   nFaces=x.grid.nFaces
@@ -160,7 +162,7 @@ function write(fil::String,x::gcmfaces)
 
 end
 
-function write(x::gcmfaces)
+function write(x::MeshArray)
 
   grTopo=x.grid.class
   nFaces=x.grid.nFaces

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -11,6 +11,7 @@ read_bin(fil::String,prec::DataType,mygrid::gcmgrid)
 read_bin(fil::String,mygrid::gcmgrid)
 ```
 """
+#deprecate documentation
 function read_bin(fil::String,kt::Union{Int,Missing},kk::Union{Int,Missing},prec::DataType,mygrid::gcmgrid)
 
   if ~ismissing(kt);

--- a/src/gcmfaces_IO.jl
+++ b/src/gcmfaces_IO.jl
@@ -84,7 +84,7 @@ function read(fil::String,x::AbstractMeshArray)
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
   n3=1
-# isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
+  isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
   isa(x,gcmfaces) ? n3=Int64(prod(size(x))/n1/n2) : nothing
 
   fid = open(fil)
@@ -99,11 +99,15 @@ function read(fil::String,x::AbstractMeshArray)
     i0=i1+1;
     nn=facesSize[iFace][1]; mm=facesSize[iFace][2];
     i1=i1+nn*mm;
-    if n3>1;
-      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3));
-    else;
-      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm));
-    end;
+    if n3>1 && isa(x,gcmfaces)
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3))
+    elseif n3>1 && isa(x,gcmarray)
+      for i3=1:n3
+        y.f[iFace,i3]=reshape(xx[i0:i1,i3],(nn,mm))
+      end
+    else
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm))
+    end
   end
 
   return y
@@ -116,7 +120,9 @@ function read(xx::Array,x::MeshArray)
   nFaces=x.grid.nFaces
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
-  n3=Int64(prod(size(x))/n1/n2)
+  n3=1
+  isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
+  isa(x,gcmfaces) ? n3=Int64(prod(size(x))/n1/n2) : nothing
 
   xx=reshape(xx,(n1*n2,n3))
 
@@ -126,11 +132,16 @@ function read(xx::Array,x::MeshArray)
     i0=i1+1;
     nn=facesSize[iFace][1]; mm=facesSize[iFace][2];
     i1=i1+nn*mm;
-    if n3>1;
-      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3));
-    else;
-      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm));
-    end;
+
+    if n3>1 && isa(x,gcmfaces)
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm,n3))
+    elseif n3>1 && isa(x,gcmarray)
+      for i3=1:n3
+        y.f[iFace,i3]=reshape(xx[i0:i1,i3],(nn,mm))
+      end
+    else
+      y.f[iFace]=reshape(xx[i0:i1,:],(nn,mm))
+    end
   end
 
   return y
@@ -144,7 +155,9 @@ function write(fil::String,x::MeshArray)
   nFaces=x.grid.nFaces
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
-  n3=Int64(prod(size(x))/n1/n2)
+  n3=1
+  isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
+  isa(x,gcmfaces) ? n3=Int64(prod(size(x))/n1/n2) : nothing
 
   y = Array{eltype(x),2}(undef,(n1*n2,n3))
   i0=0; i1=0;
@@ -168,7 +181,9 @@ function write(x::MeshArray)
   nFaces=x.grid.nFaces
   facesSize=x.grid.fSize
   (n1,n2)=x.grid.ioSize
-  n3=Int64(prod(size(x))/n1/n2)
+  n3=1
+  isa(x,gcmarray)&&(ndims(x)>1) ? n3=size(x,2) : nothing
+  isa(x,gcmfaces) ? n3=Int64(prod(size(x))/n1/n2) : nothing
 
   y = Array{eltype(x),2}(undef,(n1*n2,n3))
   i0=0; i1=0;

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -22,7 +22,6 @@ dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
 for a=1:inFLD.grid.nFaces
-  #(s1,s2)=fsize(exFLD,a)
   (s1,s2)=size(exFLD.f[a])
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -46,7 +45,6 @@ dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
 for a=1:inFLD.grid.nFaces
-  #(s1,s2)=fsize(exFLD,a)
   (s1,s2)=size(exFLD.f[a])
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
@@ -112,7 +110,6 @@ CONV=similar(uFLD)
 
 (tmpU,tmpV)=exch_UV(uFLD,vFLD)
 for a=1:tmpU.grid.nFaces
-  #(s1,s2)=fsize(uFLD,a)
   (s1,s2)=size(uFLD.f[a])
   tmpU1=view(tmpU.f[a],1:s1,1:s2)
   tmpU2=view(tmpU.f[a],2:s1+1,1:s2)

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -2,20 +2,20 @@
 ## gradient methods
 
 """
-    gradient(inFLD::gcmfaces,GridVariables::Dict)
+    gradient(inFLD::MeshArray,GridVariables::Dict)
 
 Compute spatial derivatives. Other methods:
 ```
-gradient(inFLD::gcmfaces,GridVariables::Dict,doDIV::Bool)
-gradient(inFLD::gcmfaces,iDXC::gcmfaces,iDYC::gcmfaces)
+gradient(inFLD::MeshArray,GridVariables::Dict,doDIV::Bool)
+gradient(inFLD::MeshArray,iDXC::MeshArray,iDYC::MeshArray)
 ```
 """
-function gradient(inFLD::gcmfaces,GridVariables::Dict)
+function gradient(inFLD::MeshArray,GridVariables::Dict)
 (dFLDdx, dFLDdy)=gradient(inFLD,GridVariables,true)
 return dFLDdx, dFLDdy
 end
 
-function gradient(inFLD::gcmfaces,GridVariables::Dict,doDIV::Bool)
+function gradient(inFLD::MeshArray,GridVariables::Dict,doDIV::Bool)
 
 exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
@@ -38,7 +38,7 @@ end
 return dFLDdx, dFLDdy
 end
 
-function gradient(inFLD::gcmfaces,iDXC::gcmfaces,iDYC::gcmfaces)
+function gradient(inFLD::MeshArray,iDXC::MeshArray,iDYC::MeshArray)
 
 exFLD=exchange(inFLD,1)
 dFLDdx=similar(inFLD)
@@ -58,21 +58,21 @@ end
 
 ## mask methods
 
-function mask(fld::gcmfaces)
+function mask(fld::MeshArray)
 fldmsk=mask(fld,NaN)
 return fldmsk
 end
 
 """
-    mask(fld::gcmfaces, val::Number)
+    mask(fld::MeshArray, val::Number)
 
 Replace non finite values with val. Other methods:
 ```
-mask(fld::gcmfaces)
-mask(fld::gcmfaces, val::Number, noval::Number)
+mask(fld::MeshArray)
+mask(fld::MeshArray, val::Number, noval::Number)
 ```
 """
-function mask(fld::gcmfaces, val::Number)
+function mask(fld::MeshArray, val::Number)
   fldmsk=similar(fld)
   for a=1:fld.grid.nFaces
     tmp1=copy(fld.f[a])
@@ -82,7 +82,7 @@ function mask(fld::gcmfaces, val::Number)
   return fldmsk
 end
 
-function mask(fld::gcmfaces, val::Number, noval::Number)
+function mask(fld::MeshArray, val::Number, noval::Number)
   fldmsk=similar(fld)
   for a=1:fld.grid.nFaces
     tmp1=copy(fld.f[a])
@@ -95,11 +95,11 @@ end
 ## convergence methods
 
 """
-    convergence(uFLD::gcmfaces,vFLD::gcmfaces)
+    convergence(uFLD::MeshArray,vFLD::MeshArray)
 
 Compute convergence of a vector field
 """
-function convergence(uFLD::gcmfaces,vFLD::gcmfaces)
+function convergence(uFLD::MeshArray,vFLD::MeshArray)
 
 #important note:
 #  Normally uFLD, vFLD should not contain any NaN;
@@ -124,11 +124,11 @@ end
 ## smooth function
 
 """
-    smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,GridVariables::Dict)
+    smooth(FLD::MeshArray,DXCsm::MeshArray,DYCsm::MeshArray,GridVariables::Dict)
 
 Smooth out scales below DXCsm / DYCsm via diffusion
 """
-function smooth(FLD::gcmfaces,DXCsm::gcmfaces,DYCsm::gcmfaces,GridVariables::Dict)
+function smooth(FLD::MeshArray,DXCsm::MeshArray,DYCsm::MeshArray,GridVariables::Dict)
 
 #important note:
 #input FLD should be land masked (NaN/1) by caller if needed

--- a/src/gcmfaces_calc.jl
+++ b/src/gcmfaces_calc.jl
@@ -22,7 +22,8 @@ dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
 for a=1:inFLD.grid.nFaces
-  (s1,s2)=fsize(exFLD,a)
+  #(s1,s2)=fsize(exFLD,a)
+  (s1,s2)=size(exFLD.f[a])
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
   tmpC=tmpA-view(exFLD.f[a],2:s1-1,1:s2-2)
@@ -45,7 +46,8 @@ dFLDdx=similar(inFLD)
 dFLDdy=similar(inFLD)
 
 for a=1:inFLD.grid.nFaces
-  (s1,s2)=fsize(exFLD,a)
+  #(s1,s2)=fsize(exFLD,a)
+  (s1,s2)=size(exFLD.f[a])
   tmpA=view(exFLD.f[a],2:s1-1,2:s2-1)
   tmpB=tmpA-view(exFLD.f[a],1:s1-2,2:s2-1)
   tmpC=tmpA-view(exFLD.f[a],2:s1-1,1:s2-2)
@@ -110,7 +112,8 @@ CONV=similar(uFLD)
 
 (tmpU,tmpV)=exch_UV(uFLD,vFLD)
 for a=1:tmpU.grid.nFaces
-  (s1,s2)=fsize(uFLD,a)
+  #(s1,s2)=fsize(uFLD,a)
+  (s1,s2)=size(uFLD.f[a])
   tmpU1=view(tmpU.f[a],1:s1,1:s2)
   tmpU2=view(tmpU.f[a],2:s1+1,1:s2)
   tmpV1=view(tmpV.f[a],1:s1,1:s2)

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -2,11 +2,11 @@
 ## convert2array method:
 
 """
-    convert2array(fld::AbstractMeshArray)
+    convert2array(fld::MeshArray)
 
 Convert MeshArray to Array (or vice versa otherwise)
 """
-function convert2array(fld::AbstractMeshArray)
+function convert2array(fld::MeshArray)
 
 if fld.grid.class=="llc";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -2,11 +2,11 @@
 ## convert2array method:
 
 """
-    convert2array(fld::gcmfaces)
+    convert2array(fld::AbstractMeshArray)
 
-Convert gcmfaces to array (or vice versa otherwise)
+Convert MeshArray to Array (or vice versa otherwise)
 """
-function convert2array(fld::gcmfaces)
+function convert2array(fld::AbstractMeshArray)
 
 if fld.grid.class=="llc";
     tmp1=cat(fld.f[1],fld.f[2],rotr90(fld.f[4]),rotr90(fld.f[5]);dims=1);
@@ -59,18 +59,18 @@ else;
   error("unknown grTopo case");
 end;
 
-gcmfaces(grid,v1);
+MeshArray(grid,v1);
 
 end
 
 ## convert2gcmfaces method:
 
 """
-    convert2gcmfaces(fld::gcmfaces)
+    convert2gcmfaces(fld::MeshArray)
 
-Convert mitgcm output to gcmfaces (or vice versa otherwise)
+Convert mitgcm output to MeshArray (or vice versa otherwise)
 """
-function convert2gcmfaces(fld::gcmfaces)
+function convert2gcmfaces(fld::MeshArray)
 
     grTopo=fld.grid.class
     nFaces=fld.grid.nFaces
@@ -125,6 +125,6 @@ for iFace=1:nFaces
   end;
 end
 
-gcmfaces(grid,v1);
+MeshArray(grid,v1);
 
 end

--- a/src/gcmfaces_convert.jl
+++ b/src/gcmfaces_convert.jl
@@ -6,6 +6,7 @@
 
 Convert MeshArray to Array (or vice versa otherwise)
 """
+#deprecate documentation
 function convert2array(fld::MeshArray)
 
 if fld.grid.class=="llc";
@@ -70,6 +71,7 @@ end
 
 Convert mitgcm output to MeshArray (or vice versa otherwise)
 """
+#deprecate documentation
 function convert2gcmfaces(fld::MeshArray)
 
     grTopo=fld.grid.class

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -35,15 +35,26 @@ function demo1(gridChoice::String)
     Dexch=exchange(D,4)
     Darr=mygrid.write(D)
     DD=mygrid.read(Darr,D)
+    DD .== D
 
     GridVariables=GCMGridLoad(mygrid)
 
     (dFLDdx, dFLDdy)=gradient(GridVariables["YC"],GridVariables)
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
-    #view(GridVariables["hFacC"],:,:,40)
-    #show(fsize(GridVariables["hFacC"],1))
-    #show(fsize(view(GridVariables["hFacC"],:,:,40),1))
+    H=GridVariables["hFacC"]
+    Ha=mygrid.write(H)
+    Hb=mygrid.read(Ha,H)
+
+    println(typeof(H))
+    println(size(H))
+    println(H.fSize[1])
+    println(size(H.f[1]))
+    if ndims(H)==3&&size(H,3)>40
+        println(typeof(view(H,:,:,40)))
+    elseif ndims(H.f)==2&&size(H.f,2)>40
+        println(typeof(view(H,:,40)))
+    end
 
     return (D,Dexch,Darr,DD)
 
@@ -82,9 +93,10 @@ function demo2(GridVariables::Dict)
     Rini=mygrid.read(tmp1,MeshArray(mygrid,Float32))
 
     #apply land mask
-    if ndims(GridVariables["hFacC"].f[1])>2&&isa(Rini,gcmfaces)
+    if ndims(GridVariables["hFacC"].f[1])>2
         tmp1=mask(view(GridVariables["hFacC"],:,:,1),NaN,0)
-    elseif ndims(GridVariables["hFacC"].f[1])>1&&isa(Rini,gcmarray)
+    elseif ndims(GridVariables["hFacC"].f)>1
+        #tmp1=mask(view(GridVariables["hFacC"],:,1),NaN,0)
         tmp1=similar(Rini)
         for i=1:length(tmp1.fIndex); tmp1[i]=GridVariables["hFacC"][i,1]; end;
         tmp1=mask(tmp1,NaN,0)

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -17,19 +17,19 @@ function demo1(gridChoice::String)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=mygrid.read(mygrid.path*"Depth.data",MeshArray(mygrid))
+    D=mygrid.read(mygrid.path*"Depth.data",MeshArray(mygrid,mygrid.ioPrec))
 
-    1000+D
-    D+1000
+    1000 .+ D
+    D .+ 1000
     D+D
-    D-1000
-    1000-D
+    D .- 1000
+    1000 .- D
     D-D
     1000*D
     D*1000
     D*D
     D/1000
-    1000/D
+    1000 ./ D
     D/D
 
     Dexch=exchange(D,4)
@@ -41,7 +41,7 @@ function demo1(gridChoice::String)
     (dFLDdx, dFLDdy)=gradient(GridVariables["YC"],GridVariables)
     (dFLDdxEx,dFLDdyEx)=exchange(dFLDdx,dFLDdy,4)
 
-    view(GridVariables["hFacC"],:,:,40)
+    #view(GridVariables["hFacC"],:,:,40)
     #show(fsize(GridVariables["hFacC"],1))
     #show(fsize(view(GridVariables["hFacC"],:,:,40),1))
 
@@ -82,8 +82,12 @@ function demo2(GridVariables::Dict)
     Rini=mygrid.read(tmp1,MeshArray(mygrid,Float32))
 
     #apply land mask
-    if ndims(GridVariables["hFacC"].f[1])>2
+    if ndims(GridVariables["hFacC"].f[1])>2&&isa(Rini,gcmfaces)
         tmp1=mask(view(GridVariables["hFacC"],:,:,1),NaN,0)
+    elseif ndims(GridVariables["hFacC"].f[1])>1&&isa(Rini,gcmarray)
+        tmp1=similar(Rini)
+        for i=1:length(tmp1.fIndex); tmp1[i]=GridVariables["hFacC"][i,1]; end;
+        tmp1=mask(tmp1,NaN,0)
     else
         tmp1=mask(GridVariables["hFacC"],NaN,0)
     end

--- a/src/gcmfaces_demo.jl
+++ b/src/gcmfaces_demo.jl
@@ -17,7 +17,7 @@ function demo1(gridChoice::String)
 
     mygrid=GCMGridSpec(gridChoice)
 
-    D=mygrid.read(mygrid.path*"Depth.data",gcmfaces(mygrid))
+    D=mygrid.read(mygrid.path*"Depth.data",MeshArray(mygrid))
 
     1000+D
     D+1000
@@ -79,7 +79,7 @@ function demo2(GridVariables::Dict)
 
     #initialize 2D field of random numbers
     tmp1=randn(Float32,Tuple(mygrid.ioSize))
-    Rini=mygrid.read(tmp1,gcmfaces(mygrid,Float32))
+    Rini=mygrid.read(tmp1,MeshArray(mygrid,Float32))
 
     #apply land mask
     if ndims(GridVariables["hFacC"].f[1])>2
@@ -119,17 +119,17 @@ function demo3()
     mygrid=GCMGridSpec("LLC90")
     GridVariables=GCMGridLoad(mygrid)
 
-    TrspX=mygrid.read(mygrid.path*"TrspX.bin",gcmfaces(mygrid,Float32))
-    TrspY=mygrid.read(mygrid.path*"TrspY.bin",gcmfaces(mygrid,Float32))
-    TauX=mygrid.read(mygrid.path*"TauX.bin",gcmfaces(mygrid,Float32))
-    TauY=mygrid.read(mygrid.path*"TauY.bin",gcmfaces(mygrid,Float32))
-    SSH=mygrid.read(mygrid.path*"SSH.bin",gcmfaces(mygrid,Float32))
+    TrspX=mygrid.read(mygrid.path*"TrspX.bin",MeshArray(mygrid,Float32))
+    TrspY=mygrid.read(mygrid.path*"TrspY.bin",MeshArray(mygrid,Float32))
+    TauX=mygrid.read(mygrid.path*"TauX.bin",MeshArray(mygrid,Float32))
+    TauY=mygrid.read(mygrid.path*"TauY.bin",MeshArray(mygrid,Float32))
+    SSH=mygrid.read(mygrid.path*"SSH.bin",MeshArray(mygrid,Float32))
 
     (UV, LC, Tr)=demo3(TrspX,TrspY,GridVariables)
 
 end
 
-function demo3(U::gcmfaces,V::gcmfaces,GridVariables::Dict)
+function demo3(U::MeshArray,V::MeshArray,GridVariables::Dict)
 
     LC=LatitudeCircles(-89.0:89.0,GridVariables)
 

--- a/src/gcmfaces_exch.jl
+++ b/src/gcmfaces_exch.jl
@@ -5,27 +5,27 @@
 ## User Front Ends
 
 """
-    exchange(fld::gcmfaces)
+    exchange(fld::MeshArray)
 
 Exchange / transfer data between neighboring arrays. Other methods are
 
-    exchange(fld::gcmfaces,N::Integer)
-    exchange(u::gcmfaces,v::gcmfaces)
-    exchange(u::gcmfaces,v::gcmfaces,N::Integer)
+    exchange(fld::MeshArray,N::Integer)
+    exchange(u::MeshArray,v::MeshArray)
+    exchange(u::MeshArray,v::MeshArray,N::Integer)
 """
-function exchange(fld::gcmfaces)
+function exchange(fld::MeshArray)
   FLD=exch_T_N(fld,1);
 end
 
-function exchange(fld::gcmfaces,N::Integer)
+function exchange(fld::MeshArray,N::Integer)
   FLD=exch_T_N(fld,N);
 end
 
-function exchange(u::gcmfaces,v::gcmfaces)
+function exchange(u::MeshArray,v::MeshArray)
   (uex,vex)=exch_UV_N(u,v,1);
 end
 
-function exchange(u::gcmfaces,v::gcmfaces,N::Integer)
+function exchange(u::MeshArray,v::MeshArray,N::Integer)
   (uex,vex)=exch_UV_N(u,v,N);
 end
 
@@ -83,7 +83,7 @@ end
 
 ## Grid-specific implementations: ll grid case
 
-function exch_T_N_ll(fld::gcmfaces,N::Integer)
+function exch_T_N_ll(fld::MeshArray,N::Integer)
 
 fillval=0.0
 
@@ -147,7 +147,7 @@ end
 
 #note: the "cs" implementation covers both cs and llc
 
-function exch_T_N_cs(fld::gcmfaces,N::Integer)
+function exch_T_N_cs(fld::MeshArray,N::Integer)
 
 fillval=0.0
 
@@ -195,7 +195,7 @@ end
 
 ##
 
-function exch_UV_N_cs(fldU::gcmfaces,fldV::gcmfaces,N::Integer)
+function exch_UV_N_cs(fldU::MeshArray,fldV::MeshArray,N::Integer)
 
 fillval=0.0
 
@@ -249,7 +249,7 @@ end
 
 ##
 
-function exch_UV_cs(fldU::gcmfaces,fldV::gcmfaces)
+function exch_UV_cs(fldU::MeshArray,fldV::MeshArray)
 
 fillval=0.0
 

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -65,7 +65,7 @@ function GCMGridLoad(mygrid::gcmgrid)
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","Depth")
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",gcmfaces(mygrid))
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
@@ -92,7 +92,7 @@ function GCMGridLoad(mygrid::gcmgrid)
     list0=("hFacC","hFacS","hFacW")
     n3=length(GridVariables["RC"])
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",gcmfaces(mygrid,mygrid.ioPrec,n3))
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid,mygrid.ioPrec,n3))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
@@ -123,7 +123,7 @@ function GCMGridOnes(grTp,nF,nP)
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=mygrid.read(tmp1,gcmfaces(mygrid));
+        tmp1=mygrid.read(tmp1,MeshArray(mygrid));
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
@@ -137,7 +137,7 @@ end
 """
     findtiles(ni,nj,grid="llc90")
 
-Return a `gcmfaces` map of tile indices for tile size `ni,nj`
+Return a `MeshArray` map of tile indices for tile size `ni,nj`
 """
 function findtiles(ni::Int,nj::Int,grid="llc90")
     mytiles = Dict()

--- a/src/gcmfaces_grids.jl
+++ b/src/gcmfaces_grids.jl
@@ -65,7 +65,7 @@ function GCMGridLoad(mygrid::gcmgrid)
     list0=("XC","XG","YC","YG","AngleCS","AngleSN","RAC","RAW","RAS","RAZ",
     "DXC","DXG","DYC","DYG","Depth")
     for ii=1:length(list0)
-        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid))
+        tmp1=mygrid.read(mygrid.path*list0[ii]*".data",MeshArray(mygrid,mygrid.ioPrec))
         tmp2=Symbol(list0[ii])
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1
@@ -123,7 +123,7 @@ function GCMGridOnes(grTp,nF,nP)
     list0=("XC","XG","YC","YG","RAC","RAZ","DXC","DXG","DYC","DYG","hFacC","hFacS","hFacW","Depth");
     for ii=1:length(list0);
         tmp1=fill(1.,nP,nP*nF);
-        tmp1=mygrid.read(tmp1,MeshArray(mygrid));
+        tmp1=mygrid.read(tmp1,MeshArray(mygrid,Float64));
         tmp2=Symbol(list0[ii]);
         @eval (($tmp2) = ($tmp1))
         GridVariables[list0[ii]]=tmp1

--- a/src/gcmfaces_nctiles.jl
+++ b/src/gcmfaces_nctiles.jl
@@ -14,7 +14,7 @@ export read_nctiles
 """
     read_nctiles(fileName,fldName,mygrid)
 
-Read model output from Netcdf / NCTiles file and convert to gcmfaces structure.
+Read model output from Netcdf / NCTiles file and convert to MeshArray instance.
 """
 function read_nctiles(fileName::String,fldName::String,mygrid::gcmgrid)
 
@@ -59,8 +59,7 @@ for ff=1:13;
 
 end;
 
-#return f gcmfaces object fld
-fld=gcmfaces(mygrid,f)
+fld=MeshArray(mygrid,f)
 return fld
 
 end

--- a/src/gcmfaces_plot.jl
+++ b/src/gcmfaces_plot.jl
@@ -6,9 +6,9 @@ export qwckplot
 ##  qwckplot function
 
 """
-    qwckplot(fld::gcmfaces)
+    qwckplot(fld::AbstractMeshArray)
 
-Call qwckplot(fld::gcmfaces,ttl::String) with current date for title. Example:
+Call qwckplot(fld::AbstractMeshArray,ttl::String) with current date for title. Example:
 
 ```
 !isdir("GRID_LLC90") ? error("missing files") : nothing
@@ -16,18 +16,18 @@ GridVariables=GCMGridLoad(GCMGridSpec("LLC90"))
 qwckplot(GridVariables["Depth"])
 ```
 """
-function qwckplot(fld::gcmfaces)
+function qwckplot(fld::AbstractMeshArray)
     tmp1=Dates.now()
     tmp1=Dates.format(tmp1, "yyyy-mm-dd HH:MM:SS")
     qwckplot(fld,"Plotted at time "*tmp1)
 end
 
 """
-    qwckplot(fld::gcmfaces,ttl::String)
+    qwckplot(fld::AbstractMeshArray,ttl::String)
 
 Plot input using convert2array and heatmap + add title
 """
-function qwckplot(fld::gcmfaces,ttl::String)
+function qwckplot(fld::AbstractMeshArray,ttl::String)
     arr=MeshArrays.convert2array(fld)
     arr=permutedims(arr,[2 1])
     #This uses Plots.jl:

--- a/src/gcmfaces_plot.jl
+++ b/src/gcmfaces_plot.jl
@@ -6,9 +6,9 @@ export qwckplot
 ##  qwckplot function
 
 """
-    qwckplot(fld::AbstractMeshArray)
+    qwckplot(fld::MeshArray)
 
-Call qwckplot(fld::AbstractMeshArray,ttl::String) with current date for title. Example:
+Call qwckplot(fld::MeshArray,ttl::String) with current date for title. Example:
 
 ```
 !isdir("GRID_LLC90") ? error("missing files") : nothing
@@ -16,18 +16,18 @@ GridVariables=GCMGridLoad(GCMGridSpec("LLC90"))
 qwckplot(GridVariables["Depth"])
 ```
 """
-function qwckplot(fld::AbstractMeshArray)
+function qwckplot(fld::MeshArray)
     tmp1=Dates.now()
     tmp1=Dates.format(tmp1, "yyyy-mm-dd HH:MM:SS")
     qwckplot(fld,"Plotted at time "*tmp1)
 end
 
 """
-    qwckplot(fld::AbstractMeshArray,ttl::String)
+    qwckplot(fld::MeshArray,ttl::String)
 
 Plot input using convert2array and heatmap + add title
 """
-function qwckplot(fld::AbstractMeshArray,ttl::String)
+function qwckplot(fld::MeshArray,ttl::String)
     arr=MeshArrays.convert2array(fld)
     arr=permutedims(arr,[2 1])
     #This uses Plots.jl:

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -11,7 +11,6 @@ gcmfaces data structure. Available constructors:
 gcmfaces{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int})
 gcmfaces(grid::gcmgrid,v1::Array{Array{T,N},1}) where {T,N}
-gcmfaces(A::AbstractMeshArray{T, N}) where {T,N}
 
 gcmfaces(grid::gcmgrid,::Type{T},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int}) where {T,N}
@@ -78,6 +77,7 @@ function gcmfaces(grid::gcmgrid,::Type{T},n3::Int) where {T,N}
   gcmfaces(grid,T,fSize,aSize)
 end
 
+#other possibilities:
 #gcmfaces{T,N}(grid::gcmgrid)
 #gcmfaces(grid::gcmgrid,::Type{T}) where {T}
 #gcmfaces(grid::gcmgrid,::Type{T},n3::Int) where {T}
@@ -89,13 +89,13 @@ function gcmfaces(grid::gcmgrid,
   gcmfaces{T,N}(grid,deepcopy(v1),fSize,aSize)
 end
 
-function gcmfaces(A::AbstractMeshArray{T, N}) where {T,N}
-  #should this be called similar? deepcopy?
-  fSize=fsize(A)
-  aSize=size(A)
-  grid=A.grid
-  gcmfaces{T,N}(grid,deepcopy(A.f),fSize,aSize)
-end
+#should this be called similar? deepcopy?
+#function gcmfaces(A::AbstractMeshArray{T, N}) where {T,N}
+#  fSize=fsize(A)
+#  aSize=size(A)
+#  grid=A.grid
+#  gcmfaces{T,N}(grid,deepcopy(A.f),fSize,aSize)
+#end
 
 function gcmfaces(grid::gcmgrid)
   T=grid.ioPrec
@@ -166,12 +166,12 @@ end
 
 Return vector of face array sizes. Other methods:
 ```
-fsize(A::AbstractMeshArray{T, N},i::Int) where {T,N}
+fsize(A::Union{gcmfaces{T, N},gcmsubset{T, N}},i::Int) where {T,N}
 fsize(A::Array{Array{T,N},1}) where {T,N}
 fsize(A::Array{Array{T,N},1},i::Int) where {T,N}
 ```
 """
-function fsize(A::AbstractMeshArray{T, N}) where {T,N}
+function fsize(A::Union{gcmfaces{T, N},gcmsubset{T, N}}) where {T,N}
   fs=Array{NTuple{N, Int}}(undef,A.grid.nFaces)
   for i=1:A.grid.nFaces
     fs[i]=size(A.f[i]);
@@ -179,7 +179,7 @@ function fsize(A::AbstractMeshArray{T, N}) where {T,N}
   return fs
 end
 
-function fsize(A::AbstractMeshArray{T, N},i::Int) where {T,N}
+function fsize(A::Union{gcmfaces{T, N},gcmsubset{T, N}},i::Int) where {T,N}
   if i>0
     fs=size(A.f[i])
   else
@@ -222,7 +222,7 @@ Base.size(A::gcmsubset, dim::Integer) = fsize(A.i, 0)[dim]
 
 #
 
-function Base.getindex(A::AbstractMeshArray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+function Base.getindex(A::Union{gcmfaces{T, N},gcmsubset{T, N}}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
   if typeof(I[1])<:Int
     (f,i,j)=fijind(A,I[1])
     J=Base.tail(Base.tail(I))
@@ -261,7 +261,7 @@ end
 
 #
 
-function Base.setindex!(A::AbstractMeshArray{T, N}, v, I::Vararg{Int, N}) where {T,N}
+function Base.setindex!(A::Union{gcmfaces{T, N},gcmsubset{T, N}}, v, I::Vararg{Int, N}) where {T,N}
   (f,i,j)=fijind(A,I[1])
   J=Base.tail(Base.tail(I))
   J=(i,j,J...)
@@ -275,7 +275,7 @@ end
 
 ## view
 
-function Base.view(a::AbstractMeshArray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+function Base.view(a::Union{gcmfaces{T, N},gcmsubset{T, N}}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
   nFaces=a.grid.nFaces
   grTopo=a.grid.class
   if !isa(I[1],Colon)|!isa(I[2],Colon)
@@ -295,7 +295,7 @@ end
 
 # Custom pretty-printing
 
-function Base.show(io::IO, z::AbstractMeshArray{T, N}) where {T,N}
+function Base.show(io::IO, z::Union{gcmfaces{T, N},gcmsubset{T, N}}) where {T,N}
 
 #    @printf io " MeshArrays instance with \n"
     if isa(z,gcmfaces)

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -2,31 +2,6 @@
 
 ## type definition
 
-abstract type AbstractMeshArray{T, N} <: AbstractArray{T, N} end
-
-"""
-    gcmgrid
-
-gcmgrid data structure. Available constructors:
-
-```
-gcmgrid(path::String, class::String, nFaces::Int,
-        fSize::Array{NTuple{2, Int},1}, ioSize::Array{Int64,2},
-        ioPrec::Type, read::Function, write::Function)
-```
-"""
-struct gcmgrid
-  path::String
-  class::String
-  nFaces::Int
-  fSize::Array{NTuple{2, Int},1}
-#  ioSize::NTuple{2, Int}
-  ioSize::Array{Int64,2}
-  ioPrec::Type
-  read::Function
-  write::Function
-end
-
 """
     gcmfaces{T, N}
 

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -162,7 +162,7 @@ function fijind(A::gcmfaces,ij::Int)
 end
 
 """
-    fsize(A::AbstractMeshArray{T, N}) where {T,N}
+    fsize(A::Union{gcmfaces{T, N},gcmsubset{T, N}}) where {T,N}
 
 Return vector of face array sizes. Other methods:
 ```

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -2,7 +2,7 @@
 
 ## type definition
 
-abstract type AbstractGcmfaces{T, N} <: AbstractArray{T, N} end
+abstract type AbstractMeshArray{T, N} <: AbstractArray{T, N} end
 
 """
     gcmgrid
@@ -36,7 +36,7 @@ gcmfaces data structure. Available constructors:
 gcmfaces{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int})
 gcmfaces(grid::gcmgrid,v1::Array{Array{T,N},1}) where {T,N}
-gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
+gcmfaces(A::AbstractMeshArray{T, N}) where {T,N}
 
 gcmfaces(grid::gcmgrid,::Type{T},
          fSize::Array{NTuple{N, Int}}, aSize::NTuple{N,Int}) where {T,N}
@@ -44,7 +44,7 @@ gcmfaces(grid::gcmgrid)
 gcmfaces()
 ```
 """
-struct gcmfaces{T, N} <: AbstractGcmfaces{T, N}
+struct gcmfaces{T, N} <: AbstractMeshArray{T, N}
    grid::gcmgrid
    f::Array{Array{T,N},1}
    fSize::Array{NTuple{N, Int}}
@@ -64,7 +64,7 @@ gcmsubset(grid::gcmgrid,::Type{T},fSize::Array{NTuple{N, Int}},
           aSize::NTuple{N,Int},dims::NTuple{N,Int}) where {T,N}
 ```
 """
-struct gcmsubset{T, N} <: AbstractGcmfaces{T, N}
+struct gcmsubset{T, N} <: AbstractMeshArray{T, N}
    grid::gcmgrid
    f::Array{Array{T,N},1}
    fSize::Array{NTuple{N, Int}}
@@ -114,7 +114,7 @@ function gcmfaces(grid::gcmgrid,
   gcmfaces{T,N}(grid,deepcopy(v1),fSize,aSize)
 end
 
-function gcmfaces(A::AbstractGcmfaces{T, N}) where {T,N}
+function gcmfaces(A::AbstractMeshArray{T, N}) where {T,N}
   #should this be called similar? deepcopy?
   fSize=fsize(A)
   aSize=size(A)
@@ -187,16 +187,16 @@ function fijind(A::gcmfaces,ij::Int)
 end
 
 """
-    fsize(A::AbstractGcmfaces{T, N}) where {T,N}
+    fsize(A::AbstractMeshArray{T, N}) where {T,N}
 
 Return vector of face array sizes. Other methods:
 ```
-fsize(A::AbstractGcmfaces{T, N},i::Int) where {T,N}
+fsize(A::AbstractMeshArray{T, N},i::Int) where {T,N}
 fsize(A::Array{Array{T,N},1}) where {T,N}
 fsize(A::Array{Array{T,N},1},i::Int) where {T,N}
 ```
 """
-function fsize(A::AbstractGcmfaces{T, N}) where {T,N}
+function fsize(A::AbstractMeshArray{T, N}) where {T,N}
   fs=Array{NTuple{N, Int}}(undef,A.grid.nFaces)
   for i=1:A.grid.nFaces
     fs[i]=size(A.f[i]);
@@ -204,7 +204,7 @@ function fsize(A::AbstractGcmfaces{T, N}) where {T,N}
   return fs
 end
 
-function fsize(A::AbstractGcmfaces{T, N},i::Int) where {T,N}
+function fsize(A::AbstractMeshArray{T, N},i::Int) where {T,N}
   if i>0
     fs=size(A.f[i])
   else
@@ -247,7 +247,7 @@ Base.size(A::gcmsubset, dim::Integer) = fsize(A.i, 0)[dim]
 
 #
 
-function Base.getindex(A::AbstractGcmfaces{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+function Base.getindex(A::AbstractMeshArray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
   if typeof(I[1])<:Int
     (f,i,j)=fijind(A,I[1])
     J=Base.tail(Base.tail(I))
@@ -286,7 +286,7 @@ end
 
 #
 
-function Base.setindex!(A::AbstractGcmfaces{T, N}, v, I::Vararg{Int, N}) where {T,N}
+function Base.setindex!(A::AbstractMeshArray{T, N}, v, I::Vararg{Int, N}) where {T,N}
   (f,i,j)=fijind(A,I[1])
   J=Base.tail(Base.tail(I))
   J=(i,j,J...)
@@ -300,7 +300,7 @@ end
 
 ## view
 
-function Base.view(a::AbstractGcmfaces{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
+function Base.view(a::AbstractMeshArray{T, N}, I::Vararg{Union{Int,AbstractUnitRange,Colon}, N}) where {T,N}
   nFaces=a.grid.nFaces
   grTopo=a.grid.class
   if !isa(I[1],Colon)|!isa(I[2],Colon)
@@ -320,7 +320,7 @@ end
 
 # Custom pretty-printing
 
-function Base.show(io::IO, z::AbstractGcmfaces{T, N}) where {T,N}
+function Base.show(io::IO, z::AbstractMeshArray{T, N}) where {T,N}
 
 #    @printf io " MeshArrays instance with \n"
     if isa(z,gcmfaces)

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -559,3 +559,11 @@ function fill(val::Any,a::gcmfaces)
     end
     return c
 end
+
+###
+
+function nFacesEtc(a::gcmfaces)
+  nFaces=length(a.f)
+  ndims(a.f[1])>2 ? n3=size(a.f[1],3) : n3=1
+  return nFaces, n3
+end

--- a/src/gcmfaces_type.jl
+++ b/src/gcmfaces_type.jl
@@ -28,7 +28,7 @@ end
 """
     gcmsubset{T, N}
 
-gcmsubset data structure. Available constructors:
+gcmsubset data structure for subsets of gcmfaces. Available constructors:
 
 ```
 gcmsubset{T,N}(grid::gcmgrid,f::Array{Array{T,N},1},
@@ -140,6 +140,8 @@ end
     fijind(A::gcmfaces,ij::Int)
 
 Compute face and local indices (f,j,k) from global index (ij).
+
+(needed in other types?)
 """
 function fijind(A::gcmfaces,ij::Int)
   f=0
@@ -171,6 +173,7 @@ fsize(A::Array{Array{T,N},1}) where {T,N}
 fsize(A::Array{Array{T,N},1},i::Int) where {T,N}
 ```
 """
+#deprecate documentation
 function fsize(A::Union{gcmfaces{T, N},gcmsubset{T, N}}) where {T,N}
   fs=Array{NTuple{N, Int}}(undef,A.grid.nFaces)
   for i=1:A.grid.nFaces

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using MeshArrays
 
-@testset "GCMFaces tests:" begin
+@testset "MeshArrays tests:" begin
 for nTopo=1:3
     if nTopo==1; grTopo="cs"; nFaces=6; N=200;
     elseif nTopo==2; grTopo="llc"; nFaces=5; N=200;
@@ -13,7 +13,7 @@ for nTopo=1:3
     @test mygrid.class == grTopo
     Rini= 0.; Rend= 0.;
     (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables);
-    @test isa(Rend,gcmfaces)
+    @test isa(Rend,MeshArray)
     @test sum(isfinite(Rend)) == Npt
     Sini=sqrt(sum(Rini*Rini)/(Npt-1.0))
     Send=sqrt(sum(Rend*Rend)/(Npt-1.0))


### PR DESCRIPTION
- rename `AbstractGcmfaces` as `AbstractMeshArray`, introduce `MeshArray` type alias (for now `MeshArray=gcmfaces`) and replace `::gcmfaces`, `gcmfaces()`, etc accordingly throughout the package
- move `AbstractMeshArray` + `gcmgrid` definitions to (**new**) `Types.jl` which includes both `gcmfaces` and `gcmarray`; then one of them is aliased as `MeshArray`.
- (**new**) `gcmarray_type.jl` defines `gcmarray` where each 2D tile is an array. This is simpler than what is done in `gcmfaces_type.jl` but seems to work nicely once the `Array` interface and with specialized `copyto!` so that broadcast on `x` is passed over to each tile array in `x.f`

In addition:
- avoid dispatching on `AbstractMeshArray` (use concrete types instead)
- add`nFacesEtc` in both gcmfaces and gcmarray (for eg dispatch in read / write)
- deprecate `fSize` function outside `gcmfaces_type.jl`
- add tests of dimensionality, `read`, `write`, in `demo1`
- replace gcmfaces with `MeshArray` in demos so they work also with `gcmarray` (`demo3` still need fixing in that case)